### PR TITLE
Add ffmpeg sidecar and auto export of audio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ vite.config.ts.timestamp-*
 # Tauri gen files
 src-tauri/gen
 
-# Sample audio files 
+# Sample audio files
 samples
+
+# ffmpeg sidecar binaries (populated by scripts/download-ffmpeg.sh)
+src-tauri/binaries/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To get started, cd into the project's directory and run the following commands
 
 ```bash
     npm install
+    npm run download-ffmpeg
     npm run tauri dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "download-ffmpeg": "bash scripts/download-ffmpeg.sh"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/download-ffmpeg.sh
+++ b/scripts/download-ffmpeg.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Download static ffmpeg binaries into src-tauri/binaries/ for use as a Tauri sidecar.
+#
+# Usage:
+#   ./scripts/download-ffmpeg.sh          # download for the current host platform
+#   ./scripts/download-ffmpeg.sh --all    # download for all supported platforms (CI)
+#
+# Supported target triples:
+#   aarch64-apple-darwin       (macOS Apple Silicon)
+#   x86_64-apple-darwin        (macOS Intel)
+#   x86_64-unknown-linux-gnu   (Linux x64)
+#   x86_64-pc-windows-msvc     (Windows x64, requires bash e.g. Git Bash / WSL)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINARIES_DIR="$SCRIPT_DIR/../src-tauri/binaries"
+mkdir -p "$BINARIES_DIR"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() { echo "[download-ffmpeg] $*"; }
+
+require_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        echo "Error: '$1' is required but not found on PATH." >&2
+        exit 1
+    fi
+}
+
+# Download macOS binary via Homebrew (handles both arm64 and x86_64 natively).
+download_macos() {
+    local triple="$1"   # aarch64-apple-darwin or x86_64-apple-darwin
+    local dest="$BINARIES_DIR/ffmpeg-${triple}"
+
+    log "Downloading ffmpeg for $triple via Homebrew..."
+
+    if ! command -v brew &>/dev/null; then
+        echo "Error: Homebrew not found. Install it from https://brew.sh then re-run." >&2
+        echo "  Alternatively, install ffmpeg manually and place the binary at:" >&2
+        echo "    $dest" >&2
+        exit 1
+    fi
+
+    if ! brew list ffmpeg &>/dev/null 2>&1; then
+        log "ffmpeg not installed — running 'brew install ffmpeg'..."
+        brew install ffmpeg
+    fi
+
+    local brew_ffmpeg
+    brew_ffmpeg="$(brew --prefix ffmpeg)/bin/ffmpeg"
+    if [[ ! -f "$brew_ffmpeg" ]]; then
+        echo "Error: Could not find ffmpeg binary at expected Homebrew path: $brew_ffmpeg" >&2
+        exit 1
+    fi
+
+    cp "$brew_ffmpeg" "$dest"
+    chmod +x "$dest"
+    log "Installed: $dest"
+}
+
+# Download Linux x64 binary from BtbN/FFmpeg-Builds (GPL static build).
+download_linux_x64() {
+    local triple="x86_64-unknown-linux-gnu"
+    local dest="$BINARIES_DIR/ffmpeg-${triple}"
+
+    require_cmd curl
+    require_cmd tar
+
+    log "Fetching latest BtbN release info..."
+    local asset_url
+    asset_url="$(
+        curl -fsSL "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest" \
+        | grep -o '"browser_download_url": *"[^"]*linux64-gpl[^"]*\.tar\.xz"' \
+        | grep -v "shared" \
+        | head -1 \
+        | sed 's/.*"\(https[^"]*\)".*/\1/'
+    )"
+
+    if [[ -z "$asset_url" ]]; then
+        echo "Error: Could not determine Linux64 ffmpeg download URL from BtbN releases." >&2
+        exit 1
+    fi
+
+    log "Downloading $asset_url ..."
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    trap "rm -rf '$tmpdir'" EXIT
+
+    curl -fsSL -o "$tmpdir/ffmpeg.tar.xz" "$asset_url"
+    tar -xJf "$tmpdir/ffmpeg.tar.xz" -C "$tmpdir" --wildcards "*/bin/ffmpeg" --strip-components=2
+
+    cp "$tmpdir/ffmpeg" "$dest"
+    chmod +x "$dest"
+    log "Installed: $dest"
+}
+
+# Download Windows x64 binary from BtbN/FFmpeg-Builds (GPL static build).
+download_windows_x64() {
+    local triple="x86_64-pc-windows-msvc"
+    local dest="$BINARIES_DIR/ffmpeg-${triple}.exe"
+
+    require_cmd curl
+    require_cmd unzip
+
+    log "Fetching latest BtbN release info..."
+    local asset_url
+    asset_url="$(
+        curl -fsSL "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest" \
+        | grep -o '"browser_download_url": *"[^"]*win64-gpl[^"]*\.zip"' \
+        | grep -v "shared" \
+        | head -1 \
+        | sed 's/.*"\(https[^"]*\)".*/\1/'
+    )"
+
+    if [[ -z "$asset_url" ]]; then
+        echo "Error: Could not determine Win64 ffmpeg download URL from BtbN releases." >&2
+        exit 1
+    fi
+
+    log "Downloading $asset_url ..."
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    trap "rm -rf '$tmpdir'" EXIT
+
+    curl -fsSL -o "$tmpdir/ffmpeg.zip" "$asset_url"
+    unzip -q "$tmpdir/ffmpeg.zip" "*/bin/ffmpeg.exe" -d "$tmpdir"
+    find "$tmpdir" -name "ffmpeg.exe" -exec cp {} "$dest" \;
+
+    log "Installed: $dest"
+}
+
+# ---------------------------------------------------------------------------
+# Detect host and dispatch
+# ---------------------------------------------------------------------------
+
+detect_and_download_host() {
+    local os arch triple
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64)  triple="aarch64-apple-darwin" ;;
+                x86_64) triple="x86_64-apple-darwin" ;;
+                *) echo "Unsupported macOS arch: $arch" >&2; exit 1 ;;
+            esac
+            download_macos "$triple"
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64) download_linux_x64 ;;
+                *) echo "Unsupported Linux arch: $arch (only x86_64 supported)" >&2; exit 1 ;;
+            esac
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            download_windows_x64
+            ;;
+        *)
+            echo "Unsupported OS: $os" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+    --all)
+        log "Downloading for all platforms..."
+        download_macos "aarch64-apple-darwin"
+        download_macos "x86_64-apple-darwin"
+        download_linux_x64
+        download_windows_x64
+        log "Done. All binaries written to $BINARIES_DIR/"
+        ;;
+    "")
+        detect_and_download_host
+        log "Done."
+        ;;
+    *)
+        echo "Usage: $0 [--all]" >&2
+        exit 1
+        ;;
+esac

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-shell",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -2658,6 +2659,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3629,10 +3640,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4285,6 +4328,27 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2", features = [] }
 tauri             = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-shell  = "2"
 serde             = { version = "1", features = ["derive"] }
 serde_json        = "1"
 thiserror         = "1"

--- a/src-tauri/src/audio/engine.rs
+++ b/src-tauri/src/audio/engine.rs
@@ -2,7 +2,6 @@ use std::sync::{
     mpsc::{self, SyncSender},
     Arc,
 };
-use std::path::Path;
 use rtrb::RingBuffer;
 
 use crate::error::{AppError, Result};
@@ -23,13 +22,6 @@ pub struct FileMetadata {
     pub duration_ms: u64,
     pub sample_rate: u32,
     pub channels: u16,
-}
-
-impl FileMetadata {
-    pub fn file_name_prefix(&self) -> Option<String> {
-        let path = Path::new(&self.file_name);
-        Some(path.file_stem()?.to_str()?.to_string())
-    }
 }
 
 /// The live audio engine for a single loaded file.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::audio::{AudioEngine, FileMetadata};
 use crate::error::{AppError, Result};
-use crate::export::write_csv;
+use crate::export::export_segments;
 use crate::markers::{Marker, MarkerKind, Segment};
 use crate::state::AppState;
 
@@ -197,38 +197,40 @@ pub async fn validate_markers(state: State<'_, AppState>) -> Result<Vec<Segment>
 }
 
 // ---------------------------------------------------------------------------
-// CSV export
+// Audio segment export
 // ---------------------------------------------------------------------------
 
+/// Validate the current markers into segments, open a folder-picker dialog, then
+/// extract each segment from the loaded audio file using the bundled ffmpeg sidecar.
+/// Returns the number of segment files written.
 #[tauri::command]
-pub async fn export_csv(app: AppHandle, state: State<'_, AppState>) -> Result<()> {
+pub async fn export_audio_segments(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<u32> {
     use tauri_plugin_dialog::DialogExt;
 
-    // Validate markers first — errors surface before the dialog opens.
     let segments = state.markers.lock().to_segments()?;
-
-    let mut file_name = String::from("segments.txt");
-    if let Some(engine) = state.engine.lock().as_ref() {
-        if let Some(name) = engine.metadata.file_name_prefix() {
-            file_name = format!("{name}.txt")
-        };
-        println!("{}", file_name)
+    if segments.is_empty() {
+        return Err(AppError::ValidationError("No segments to export".into()));
     }
 
-    let save_path = app
+    let source_path = {
+        let engine = state.engine.lock();
+        engine.as_ref().ok_or(AppError::NoFileLoaded)?.metadata.file_path.clone()
+    };
+
+    let output_dir = app
         .dialog()
         .file()
-        .set_file_name(file_name.as_str())
-        .add_filter("CSV", &["csv"])
-        .add_filter("TXT", &["txt"])
-        .blocking_save_file()
+        .blocking_pick_folder()
         .ok_or(AppError::DialogCancelled)?;
 
-    let path = save_path.to_string();
+    let output_path = output_dir
+        .as_path()
+        .ok_or_else(|| AppError::ValidationError("Invalid output directory path".into()))?;
 
-    let file = std::fs::File::create(path)?;
-    write_csv(file, &segments)?;
-    Ok(())
+    export_segments(&app, &source_path, &segments, output_path).await
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -20,6 +20,10 @@ pub enum AppError {
     Csv(#[from] csv::Error),
     #[error("Dialog cancelled")]
     DialogCancelled,
+    #[error("ffmpeg sidecar not available: {0}")]
+    FfmpegNotFound(String),
+    #[error("ffmpeg failed on segment '{0}': {1}")]
+    FfmpegFailed(String, String),
 }
 
 // Tauri requires command errors to be serializable so they can be sent over IPC.

--- a/src-tauri/src/export/csv.rs
+++ b/src-tauri/src/export/csv.rs
@@ -8,12 +8,10 @@ pub fn ms_to_timestamp(ms: u64) -> String {
     let secs = total_secs % 60;
     let minutes = (total_secs / 60) % 60;
     let hours = total_secs / 3600;
-    format!("{:01}:{:02}:{:02}.{:03}", hours, minutes, secs, millis)
+    format!("{:02}:{:02}:{:02}.{:03}", hours, minutes, secs, millis)
 }
 
-/// Write `segments` as RFC 4180 CSV to an arbitrary writer.
-///
-/// Header: `start_time,end_time,title`
+/// Write `segments` to an arbitrary writer.
 pub fn write_csv<W: std::io::Write>(writer: W, segments: &[Segment]) -> Result<()> {
     let mut wtr = csv::Writer::from_writer(writer);
     let mut counter = 1;
@@ -71,24 +69,20 @@ mod tests {
     // --- CSV write tests ---
 
     #[test]
-    fn empty_segments_produces_header_only() {
+    fn empty_segments_produces_no_output() {
         let mut buf: Vec<u8> = Vec::new();
         write_csv(&mut buf, &[]).unwrap();
-        let s = String::from_utf8(buf).unwrap();
-        let lines: Vec<&str> = s.lines().collect();
-        assert_eq!(lines.len(), 1);
-        assert_eq!(lines[0], "start_time,end_time,title");
+        assert!(String::from_utf8(buf).unwrap().is_empty());
     }
 
     #[test]
-    fn single_segment_produces_header_and_one_row() {
+    fn single_segment_produces_one_row() {
         let mut buf: Vec<u8> = Vec::new();
         write_csv(&mut buf, &[seg(0, 5000, "001 Segment")]).unwrap();
         let s = String::from_utf8(buf).unwrap();
         let lines: Vec<&str> = s.lines().collect();
-        assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0], "start_time,end_time,title");
-        assert_eq!(lines[1], "00:00:00.000,00:00:05.000,001 Segment");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "1,00:00:00.000,00:00:05.000,001 Segment");
     }
 
     #[test]
@@ -101,8 +95,8 @@ mod tests {
         write_csv(&mut buf, &segs).unwrap();
         let s = String::from_utf8(buf).unwrap();
         let lines: Vec<&str> = s.lines().collect();
-        assert_eq!(lines.len(), 3);
-        assert_eq!(lines[2], "00:00:06.000,00:00:10.000,002 Segment");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[1], "2,00:00:06.000,00:00:10.000,002 Segment");
     }
 
     #[test]

--- a/src-tauri/src/export/mod.rs
+++ b/src-tauri/src/export/mod.rs
@@ -1,3 +1,4 @@
 pub mod csv;
+pub mod segments;
 
-pub use csv::write_csv;
+pub use segments::export_segments;

--- a/src-tauri/src/export/segments.rs
+++ b/src-tauri/src/export/segments.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+
+use tauri::AppHandle;
+use tauri_plugin_shell::ShellExt;
+
+use crate::error::{AppError, Result};
+use crate::markers::Segment;
+use super::csv::{ms_to_timestamp, write_csv};
+
+/// Strip characters that are invalid in file names on Windows, macOS, or Linux.
+fn sanitize_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .filter(|c| !matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'))
+        .collect();
+    let trimmed = cleaned.trim().to_string();
+    if trimmed.is_empty() {
+        "untitled".to_string()
+    } else {
+        trimmed
+    }
+}
+
+/// Extract `segments` from `source_file` into individual files under `output_dir`.
+///
+/// Invokes the bundled ffmpeg sidecar once per segment. Also writes a TOC text
+/// file (`{stem}.txt`) in the output directory listing each segment's duration.
+///
+/// Returns the number of segments written.
+pub async fn export_segments(
+    app: &AppHandle,
+    source_file: &str,
+    segments: &[Segment],
+    output_dir: &Path,
+) -> Result<u32> {
+    std::fs::create_dir_all(output_dir)?;
+
+    let source_path = Path::new(source_file);
+    let ext = source_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("mp3");
+    let stem = source_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output");
+
+    let mut toc_lines: Vec<String> = Vec::new();
+
+    for (i, seg) in segments.iter().enumerate() {
+        let index = i + 1;
+        let title = sanitize_filename(&seg.title);
+        let filename = format!("{:02} {}.{}", index, title, ext);
+        let output_path: PathBuf = output_dir.join(&filename);
+
+        let start = ms_to_timestamp(seg.start_ms);
+        let end = ms_to_timestamp(seg.end_ms);
+
+        let output = app
+            .shell()
+            .sidecar("ffmpeg")
+            .map_err(|e| AppError::FfmpegNotFound(e.to_string()))?
+            .args([
+                "-hide_banner",
+                "-loglevel", "error",
+                "-y",
+                "-ss", &start,
+                "-to", &end,
+                "-i", source_file,
+                output_path.to_str().unwrap_or_default(),
+            ])
+            .output()
+            .await
+            .map_err(|e| AppError::FfmpegNotFound(e.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            return Err(AppError::FfmpegFailed(filename, stderr));
+        }
+
+        let duration = ms_to_timestamp(seg.end_ms.saturating_sub(seg.start_ms));
+        toc_lines.push(format!("[{}] {}", duration, filename));
+    }
+
+    // Write the CSV index file.
+    let csv_path = output_dir.join(format!("{}.csv", stem));
+    let csv_file = std::fs::File::create(csv_path)?;
+    write_csv(csv_file, segments)?;
+
+    Ok(segments.len() as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_filename;
+
+    #[test]
+    fn strips_invalid_chars() {
+        assert_eq!(sanitize_filename("hello/world"), "helloworld");
+        assert_eq!(sanitize_filename("foo:bar"), "foobar");
+        assert_eq!(sanitize_filename(r#"a\b*c?d"e<f>g|h"#), "abcdefgh");
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        assert_eq!(sanitize_filename("  hello  "), "hello");
+    }
+
+    #[test]
+    fn empty_becomes_untitled() {
+        assert_eq!(sanitize_filename(""), "untitled");
+        assert_eq!(sanitize_filename("   "), "untitled");
+        assert_eq!(sanitize_filename("///"), "untitled");
+    }
+
+    #[test]
+    fn normal_title_unchanged() {
+        assert_eq!(sanitize_filename("01 Opening Theme"), "01 Opening Theme");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_shell::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::open_file,
@@ -32,7 +33,7 @@ pub fn run() {
             commands::rename_segment,
             commands::list_markers,
             commands::validate_markers,
-            commands::export_csv,
+            commands::export_audio_segments,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/ffmpeg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
 
-  let { onOpenFile, onExportCsv }: {
+  let { onOpenFile, onExportAudioSegments }: {
     onOpenFile: () => void;
-    onExportCsv: () => void;
+    onExportAudioSegments: () => void;
   } = $props();
 </script>
 
@@ -22,13 +22,13 @@
       </svg>
       Open File
     </button>
-    <button class="btn-export" onclick={onExportCsv}>
+    <button class="btn-export" onclick={onExportAudioSegments}>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
         <polyline points="7 10 12 15 17 10"/>
         <line x1="12" y1="15" x2="12" y2="3"/>
       </svg>
-      Export CSV
+      Export 
     </button>
   </div>
 </header>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -313,13 +313,24 @@
       appState.error = String(e);
     }
   }
+
+  async function exportAudioSegments() {
+    try {
+      appState.error = null;
+      await invoke('export_audio_segments');
+    } catch (e) {
+      appState.error = String(e);
+    }
+  }
 </script>
 
 {#if !appState.metadata}
   <WelcomeScreen onOpenFile={openFile} />
 {:else}
   <div class="app">
-    <Header onOpenFile={openFile} onExportCsv={exportCsv} />
+    <Header onOpenFile={openFile}
+            onExportAudioSegments={exportAudioSegments}
+    />
     <WaveformDisplay />
     <PlaybackControls
       onStepBack={stepBack}


### PR DESCRIPTION
This PR introduces the functionality mention in issue #8 to export the audio files (and a corresponding csv with the segments) directly rather than solely exporting a CSV and relying on the user to run the provided SNOBOL script. To do this FFMPEG is bundled directly into the app using the Tauri sidecar functionality (which should be fun because the FFMPEG binary is pretty small). 