### PR TITLE
Automatic verification of ffmpeg sidecar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ To get started, cd into the project's directory and run the following commands
 
 ```bash
     npm install
-    npm run download-ffmpeg
     npm run tauri dev
 ```
+
+`npm run tauri dev` automatically ensures the required ffmpeg sidecar exists before Tauri starts. You can still run `npm run download-ffmpeg` manually if you need to refresh it.
 
 ## Testing 
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri",
+    "ensure-ffmpeg": "bash scripts/download-ffmpeg.sh",
     "download-ffmpeg": "bash scripts/download-ffmpeg.sh",
+    "pretauri": "npm run ensure-ffmpeg",
+    "tauri": "tauri",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage"

--- a/scripts/download-ffmpeg.sh
+++ b/scripts/download-ffmpeg.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Download static ffmpeg binaries into src-tauri/binaries/ for use as a Tauri sidecar.
+# Ensure ffmpeg binaries exist in src-tauri/binaries/ for use as Tauri sidecars.
 #
 # Usage:
-#   ./scripts/download-ffmpeg.sh          # download for the current host platform
-#   ./scripts/download-ffmpeg.sh --all    # download for all supported platforms (CI)
+#   ./scripts/download-ffmpeg.sh          # ensure the current host platform binary exists
+#   ./scripts/download-ffmpeg.sh --all    # download/refresh all supported platform binaries (CI)
 #
 # Supported target triples:
 #   aarch64-apple-darwin       (macOS Apple Silicon)
@@ -23,6 +23,21 @@ mkdir -p "$BINARIES_DIR"
 
 log() { echo "[download-ffmpeg] $*"; }
 
+sidecar_ready() {
+    local path="$1"
+
+    if [[ -f "$path" ]]; then
+        if [[ ! -x "$path" ]]; then
+            chmod +x "$path"
+        fi
+
+        log "Using existing ffmpeg sidecar: $path"
+        return 0
+    fi
+
+    return 1
+}
+
 require_cmd() {
     if ! command -v "$1" &>/dev/null; then
         echo "Error: '$1' is required but not found on PATH." >&2
@@ -35,7 +50,11 @@ download_macos() {
     local triple="$1"   # aarch64-apple-darwin or x86_64-apple-darwin
     local dest="$BINARIES_DIR/ffmpeg-${triple}"
 
-    log "Downloading ffmpeg for $triple via Homebrew..."
+    if sidecar_ready "$dest"; then
+        return 0
+    fi
+
+    log "Installing ffmpeg sidecar for $triple via Homebrew..."
 
     if ! command -v brew &>/dev/null; then
         echo "Error: Homebrew not found. Install it from https://brew.sh then re-run." >&2
@@ -65,6 +84,10 @@ download_macos() {
 download_linux_x64() {
     local triple="x86_64-unknown-linux-gnu"
     local dest="$BINARIES_DIR/ffmpeg-${triple}"
+
+    if sidecar_ready "$dest"; then
+        return 0
+    fi
 
     require_cmd curl
     require_cmd tar
@@ -101,6 +124,10 @@ download_linux_x64() {
 download_windows_x64() {
     local triple="x86_64-pc-windows-msvc"
     local dest="$BINARIES_DIR/ffmpeg-${triple}.exe"
+
+    if sidecar_ready "$dest"; then
+        return 0
+    fi
 
     require_cmd curl
     require_cmd unzip


### PR DESCRIPTION
This PR expands on PR #11, which bundled ffmpeg as a sidecar into the application. This required manually invoking the download script by executing `npm run download-ffmpeg` in the terminal. Now, the execution of this script is added a pre-tauri lifecycle in package.json so it executes whenever `npm run tauri dev` is ran in the terminal. The script itself has been modified to first check whether the binary exists, in which case, it exits; otherwise, it downloads the binary to the proper path for the proper system as before. 