### PR TITLE
Add marker position fine-tuning feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.53.0.tgz",
-      "integrity": "sha512-Brh/9h8QEg7rWIj+Nnz/2sC49NUeS8g3Qd9H5dTO3EbWG8vCEUl06jE+r5jQVDMHdr1swmCkwZkONFsWelGTpQ==",
+      "version": "2.57.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
+      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1193,7 +1193,7 @@
         "@types/cookie": "^0.6.0",
         "acorn": "^8.14.1",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.3",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
@@ -1211,7 +1211,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": "^5.3.3",
+        "typescript": "^5.3.3 || ^6.0.0",
         "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -1891,9 +1891,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
-      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1974,13 +1974,21 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
-      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/estree-walker": {
@@ -2347,9 +2355,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2600,9 +2608,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.3",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.3.tgz",
-      "integrity": "sha512-pRUBr6j6uQDgBi208gHnGRMykw0Rf2Yr1HmLyRucsvcaYgIUxswJkT93WZJflsmezu5s8Lq+q78EoyLv2yaFCg==",
+      "version": "5.55.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
+      "integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2615,9 +2623,9 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -2783,9 +2791,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
-  import { formatMs } from '$lib/utils';
+  import { formatMs, parseTimeMs } from '$lib/utils';
+  import { enterEditMode, cancelEditMode, confirmEditMode } from '$lib/actions';
   import type { MarkerKind } from '$lib/types';
 
   let { onAddMarkerNoKind, onDeleteMarker, onAddMarkerAt }: {
@@ -8,6 +9,20 @@
     onDeleteMarker: (id: string) => Promise<void>;
     onAddMarkerAt: (kind: MarkerKind, pos: number) => Promise<void>;
   } = $props();
+
+  // Local string state for the edit input — avoids fighting the user while typing
+  let editInputValue = $state('');
+  // True while the user has the edit input focused; suppresses the $effect reset
+  let isTyping = false;
+
+  // Sync the input display when the draft position changes externally (nudge or mode entry)
+  // but not while the user is actively typing in the field.
+  $effect(() => {
+    if (appState.editingMarkerId !== null && !isTyping) {
+      editInputValue = formatMs(appState.editingPositionMs);
+    }
+  });
+
 </script>
 
 <div class="panel">
@@ -26,6 +41,7 @@
         <div
           class="marker-row"
           class:marker-row-selected={appState.selectedMarkerId === m.id}
+          class:marker-row-editing={appState.editingMarkerId === m.id}
           onclick={() => { appState.selectedMarkerId = m.id; }}
           role="button"
           tabindex="0"
@@ -37,7 +53,47 @@
             class:dot-end={m.kind === 'end'}
             class:dot-both={m.kind === 'startEnd'}
           ></span>
-          <span class="marker-time">{formatMs(m.position)}</span>
+          {#if appState.editingMarkerId === m.id}
+            <input
+              class="edit-time-input"
+              type="text"
+              bind:value={editInputValue}
+              onfocus={() => { isTyping = true; }}
+              onblur={() => {
+                isTyping = false;
+                // Reformat to canonical display if the user left without confirming
+                editInputValue = formatMs(appState.editingPositionMs);
+              }}
+              oninput={() => {
+                // Update the draft position in real-time so the waveform follows along
+                const parsed = parseTimeMs(editInputValue);
+                if (parsed !== null) {
+                  appState.editingPositionMs = Math.max(0, Math.min(parsed, appState.durationMs));
+                }
+              }}
+              onkeydown={(e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  isTyping = false;
+                  // Apply whatever the user typed (flexible format) before saving
+                  const parsed = parseTimeMs(editInputValue);
+                  if (parsed !== null) {
+                    appState.editingPositionMs = Math.max(0, Math.min(parsed, appState.durationMs));
+                  }
+                  confirmEditMode();
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  isTyping = false;
+                  cancelEditMode();
+                }
+              }}
+            />
+          {:else}
+            <span class="marker-time">{formatMs(m.position)}</span>
+          {/if}
           <select
             class="kind-select"
             class:kind-unselected={appState.unkindedMarkers.has(m.id)}
@@ -64,6 +120,21 @@
             <option value="end">End</option>
             <option value="startEnd">Start+End</option>
           </select>
+          <button
+            class="edit-btn"
+            class:edit-btn-active={appState.editingMarkerId === m.id}
+            onclick={(e) => {
+              e.stopPropagation();
+              if (appState.editingMarkerId === m.id) cancelEditMode();
+              else enterEditMode(m.id);
+            }}
+            title={appState.editingMarkerId === m.id ? 'Cancel editing' : 'Edit marker position'}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+            </svg>
+          </button>
           <button
             class="delete-btn"
             onclick={(e) => { e.stopPropagation(); onDeleteMarker(m.id); }}
@@ -212,4 +283,37 @@
     border-color: #f87171;
     background: #1e1010;
   }
+
+  .marker-row-editing { background: #1e1a0e !important; border-left: 2px solid #f97316; }
+
+  .edit-time-input {
+    flex: 1;
+    padding: 3px 6px;
+    background: #1e2a3a;
+    border: 1px solid #f97316;
+    border-radius: 5px;
+    color: #f97316;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    outline: none;
+    min-width: 0;
+  }
+
+  .edit-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: #4d5b6b;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    flex-shrink: 0;
+  }
+
+  .edit-btn:hover { color: #f97316; border-color: #f97316; background: #1e1a0e; }
+  .edit-btn-active { color: #f97316; border-color: #f97316; background: #1e1a0e; }
 </style>

--- a/src/components/SegmentPanel.svelte
+++ b/src/components/SegmentPanel.svelte
@@ -1,26 +1,30 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
   import { formatMs } from '$lib/utils';
+  import { computePreviewSegments } from '$lib/actions';
 
   let { onRenameSegment }: {
     onRenameSegment: (anchorId: string) => Promise<void>;
   } = $props();
+
+  const displaySegments = $derived(computePreviewSegments());
+  const isPreviewing    = $derived(appState.editingMarkerId !== null);
 </script>
 
 <div class="panel">
   <div class="panel-header">
-    <h3 class="panel-title">Segments ({appState.segments?.length ?? 0})</h3>
+    <h3 class="panel-title">Segments ({displaySegments.length})</h3>
   </div>
 
   {#if appState.validationError}
     <p class="validation-error">{appState.validationError}</p>
   {/if}
 
-  {#if appState.segments === null || appState.segments.length === 0}
+  {#if displaySegments.length === 0}
     <p class="empty-state">No segments yet. Add start and end markers to create segments.</p>
   {:else}
-    <div class="segment-list">
-      {#each [...appState.segments].sort((a, b) => b.endMs - a.endMs) as seg, i}
+    <div class="segment-list" class:segment-list-preview={isPreviewing}>
+      {#each [...displaySegments].sort((a, b) => b.endMs - a.endMs) as seg, i}
         <div class="segment-row">
           <span class="seg-index">{String(i + 1).padStart(3, '0')}</span>
           <div class="seg-times">
@@ -149,4 +153,6 @@
 
   .seg-title-input:focus { border-color: #2563eb; background: #1a2332; }
   .seg-title-input::placeholder { color: #4d5b6b; }
+
+  .segment-list-preview { opacity: 0.75; }
 </style>

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -35,6 +35,12 @@
     <div class="shortcut-row"><kbd>F</kbd><span>Next Marker</span></div>
     <div class="shortcut-row"><kbd>Del</kbd><span>Delete Selected Marker</span></div>
 
+    <div class="shortcut-subheading">Edit Marker</div>
+    <div class="shortcut-row"><kbd>[</kbd><span>Nudge left 100ms</span></div>
+    <div class="shortcut-row"><kbd>]</kbd><span>Nudge right 100ms</span></div>
+    <div class="shortcut-row"><kbd>Enter</kbd><span>Confirm position</span></div>
+    <div class="shortcut-row"><kbd>Esc</kbd><span>Cancel editing</span></div>
+
     <div class="shortcut-subheading">Export</div>
     <div class="shortcut-row"><kbd>Ctrl+E</kbd><span>Export CSV</span></div>
   </div>

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -104,13 +104,30 @@
   <div class="waveform-inner" bind:this={waveformEl}></div>
   <!-- Marker overlays -->
   {#each appState.markers as m (m.id)}
-    {@const pct = appState.durationMs > 0 ? (m.position / appState.durationMs) * 100 : 0}
-    <div
-      class="marker-line"
-      class:marker-selected={appState.selectedMarkerId === m.id}
-      style="left: {pct}%"
-      title="{kindLabel(m.kind)} — {formatMs(m.position)}"
-    ></div>
+    {@const isEditing = appState.editingMarkerId === m.id}
+    {@const draftPct  = appState.durationMs > 0 ? (appState.editingPositionMs / appState.durationMs) * 100 : 0}
+    {@const origPct   = appState.durationMs > 0 ? (m.position / appState.durationMs) * 100 : 0}
+    {#if isEditing}
+      <!-- Ghost at original position -->
+      <div
+        class="marker-line marker-ghost"
+        style="left: {origPct}%"
+        title="Original — {formatMs(m.position)}"
+      ></div>
+      <!-- Draft at new position -->
+      <div
+        class="marker-line marker-editing"
+        style="left: {draftPct}%"
+        title="{kindLabel(m.kind)} — {formatMs(appState.editingPositionMs)}"
+      ></div>
+    {:else}
+      <div
+        class="marker-line"
+        class:marker-selected={appState.selectedMarkerId === m.id}
+        style="left: {origPct}%"
+        title="{kindLabel(m.kind)} — {formatMs(m.position)}"
+      ></div>
+    {/if}
   {/each}
 </div>
 
@@ -147,5 +164,22 @@
     opacity: 1;
     width: 2px;
     box-shadow: 0 0 6px #facc15;
+  }
+
+  .marker-line.marker-ghost {
+    background: #22c55e;
+    opacity: 0.3;
+  }
+
+  .marker-line.marker-editing {
+    background: #f97316;
+    opacity: 1;
+    box-shadow: 0 0 8px #f97316;
+    animation: editing-pulse 1s ease-in-out infinite alternate;
+  }
+
+  @keyframes editing-pulse {
+    from { opacity: 0.6; }
+    to   { opacity: 1; }
   }
 </style>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -63,12 +63,29 @@ export function handleKeydown(e: KeyboardEvent) {
   if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) return;
   if (!appState.metadata) return;
 
+  if (e.key === 'Escape' && appState.editingMarkerId) {
+    e.preventDefault();
+    cancelEditMode();
+    return;
+  }
+  if (e.key === 'Enter' && appState.editingMarkerId) {
+    e.preventDefault();
+    confirmEditMode();
+    return;
+  }
+
   if (e.code === 'Space') {
     e.preventDefault();
     togglePlay();
   } else if ((e.ctrlKey || e.metaKey) && e.key === 'e') {
     e.preventDefault();
     exportCsv();
+  } else if (e.key === '[') {
+    e.preventDefault();
+    nudgeMarker(-1);
+  } else if (e.key === ']') {
+    e.preventDefault();
+    nudgeMarker(1);
   } else if (e.key === 's' || e.key === 'S') {
     e.preventDefault();
     addMarker('start');
@@ -122,14 +139,20 @@ export async function seekToPrevMarker() {
   const prev = [...appState.markers]
     .filter(m => m.position < appState.positionMs - 50)
     .sort((a, b) => b.position - a.position)[0];
-  if (prev) await seekTo(prev.position);
+  if (prev) {
+    appState.selectedMarkerId = prev.id;
+    await seekTo(prev.position);
+  }
 }
 
 export async function seekToNextMarker() {
   const next = appState.markers
     .filter(m => m.position > appState.positionMs + 50)
     .sort((a, b) => a.position - b.position)[0];
-  if (next) await seekTo(next.position);
+  if (next) {
+    appState.selectedMarkerId = next.id;
+    await seekTo(next.position);
+  }
 }
 
 export async function stepBack() {
@@ -149,10 +172,12 @@ export async function openFile() {
     appState.metadata        = meta;
     appState.durationMs      = meta.durationMs;
     appState.positionMs      = 0;
-    appState.markers         = [];
-    appState.segments        = null;
-    appState.renameInputs    = {};
+    appState.markers          = [];
+    appState.segments         = null;
+    appState.renameInputs     = {};
     appState.selectedMarkerId = null;
+    appState.editingMarkerId  = null;
+    appState.editingPositionMs = 0;
     startPolling();
     startRaf();
   } catch (e) {
@@ -237,6 +262,7 @@ export async function deleteMarker(id: string) {
     delete updated[id];
     appState.renameInputs = updated;
     if (appState.selectedMarkerId === id) appState.selectedMarkerId = null;
+    if (appState.editingMarkerId === id) { appState.editingMarkerId = null; appState.editingPositionMs = 0; }
     if (appState.unkindedMarkers.has(id)) {
       const s = new Set(appState.unkindedMarkers);
       s.delete(id);
@@ -246,6 +272,81 @@ export async function deleteMarker(id: string) {
   } catch (e) {
     appState.error = String(e);
   }
+}
+
+// ── Marker position editing ───────────────────────────────────────────────
+
+export function enterEditMode(markerId: string) {
+  const marker = appState.markers.find(m => m.id === markerId);
+  if (!marker) return;
+  appState.editingMarkerId   = markerId;
+  appState.editingPositionMs = marker.position;
+  appState.selectedMarkerId  = markerId;
+}
+
+export function cancelEditMode() {
+  appState.editingMarkerId   = null;
+  appState.editingPositionMs = 0;
+}
+
+export async function confirmEditMode() {
+  if (!appState.editingMarkerId) return;
+  const id         = appState.editingMarkerId;
+  const positionMs = Math.round(appState.editingPositionMs);
+  appState.editingMarkerId   = null;
+  appState.editingPositionMs = 0;
+  try {
+    appState.error = null;
+    await invoke('move_marker', { id, newPositionMs: positionMs });
+    appState.markers = appState.markers
+      .map(m => m.id === id ? { ...m, position: positionMs } : m)
+      .sort((a, b) => a.position - b.position);
+    await revalidate();
+  } catch (e) {
+    appState.error = String(e);
+  }
+}
+
+export function nudgeMarker(direction: -1 | 1) {
+  if (!appState.editingMarkerId) {
+    if (!appState.selectedMarkerId) return;
+    enterEditMode(appState.selectedMarkerId);
+  }
+  const newPos = appState.editingPositionMs + direction * appState.nudgeStepMs;
+  appState.editingPositionMs = Math.max(0, Math.min(newPos, appState.durationMs));
+}
+
+export function computePreviewSegments(): Segment[] {
+  if (!appState.editingMarkerId) return appState.segments ?? computePartialSegments();
+
+  const previewMarkers = appState.markers
+    .map(m => m.id === appState.editingMarkerId ? { ...m, position: appState.editingPositionMs } : m)
+    .sort((a, b) => a.position - b.position);
+
+  const result: Segment[] = [];
+  let pendingStart: Marker | null = null;
+
+  for (const m of previewMarkers) {
+    if (m.kind === 'startEnd') {
+      if (pendingStart) {
+        result.push({ startMs: pendingStart.position, endMs: m.position,
+          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
+        pendingStart = m;
+      } else {
+        result.push({ startMs: m.position, endMs: m.position,
+          title: appState.renameInputs[m.id] || `Segment ${result.length}` });
+      }
+    } else if (m.kind === 'start') {
+      pendingStart = m;
+    } else if (m.kind === 'end') {
+      if (pendingStart) {
+        result.push({ startMs: pendingStart.position, endMs: m.position,
+          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
+        pendingStart = null;
+      }
+    }
+  }
+  return result;
 }
 
 export async function renameSegment(anchorId: string) {

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -16,6 +16,9 @@ class AppState {
   renameInputs    = $state<Record<string, string>>({});
   selectedMarkerId  = $state<string | null>(null);
   validationError   = $state<string | null>(null);
+  editingMarkerId   = $state<string | null>(null);
+  editingPositionMs = $state(0);
+  nudgeStepMs       = 100;
   unkindedMarkers = $state<Set<string>>(new Set());
   // Lets the RAF in +page.svelte skip interpolation during waveform drag
   waveformDragging = $state(false);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,56 @@ export function kindLabel(kind: MarkerKind): string {
 }
 
 export const SPEEDS = [0.5, 0.75, 1, 1.5, 2];
+
+// Parses a flexible time string back to milliseconds. Accepted formats:
+//   "5"          → 5 seconds
+//   "5.5"        → 5.5 seconds (500 ms)
+//   "1:30"       → 1 min 30 s
+//   "1:30.5"     → 1 min 30.5 s
+//   "1:30:00"    → 1 h 30 min
+//   "HH:MM:SS.mmm" → exact format produced by formatMs
+// Millisecond digits are padded/truncated to 3 places.
+// Returns null if the string cannot be interpreted.
+export function parseTimeMs(value: string): number | null {
+  const s = value.trim();
+  if (!s) return null;
+
+  const parts = s.split(':');
+  if (parts.length > 3) return null;
+
+  // Last segment may carry a decimal for sub-second precision
+  const lastPart = parts[parts.length - 1];
+  const dotIdx   = lastPart.indexOf('.');
+  let secondsInt: number;
+  let millis = 0;
+
+  if (dotIdx !== -1) {
+    const secStr = lastPart.slice(0, dotIdx);
+    const milStr = lastPart.slice(dotIdx + 1);
+    secondsInt = parseInt(secStr || '0', 10);
+    // Pad to 3 digits (e.g. "5" → "500", "50" → "500", "500" → "500")
+    const milPadded = milStr.slice(0, 3).padEnd(3, '0');
+    millis = parseInt(milPadded, 10);
+  } else {
+    secondsInt = parseInt(lastPart || '0', 10);
+  }
+
+  if (isNaN(secondsInt) || isNaN(millis)) return null;
+
+  let minutes = 0;
+  let hours   = 0;
+
+  if (parts.length >= 2) {
+    minutes = parseInt(parts[parts.length - 2] || '0', 10);
+    if (isNaN(minutes) || minutes > 59) return null;
+  }
+  if (parts.length === 3) {
+    hours = parseInt(parts[0] || '0', 10);
+    if (isNaN(hours)) return null;
+  }
+
+  // Seconds must be 0–59 when part of a compound expression (1:90 is invalid)
+  if (parts.length > 1 && secondsInt > 59) return null;
+
+  return hours * 3_600_000 + minutes * 60_000 + secondsInt * 1_000 + millis;
+}

--- a/src/tests/helpers/reset-state.ts
+++ b/src/tests/helpers/reset-state.ts
@@ -12,8 +12,10 @@ export function resetAppState() {
   appState.speed            = 1.0;
   appState.looping          = false;
   appState.renameInputs     = {};
-  appState.selectedMarkerId = null;
-  appState.validationError  = null;
+  appState.selectedMarkerId  = null;
+  appState.validationError   = null;
+  appState.editingMarkerId   = null;
+  appState.editingPositionMs = 0;
   appState.unkindedMarkers  = new Set();
   appState.waveformDragging = false;
   appState.syncPositionMs   = 0;

--- a/src/tests/unit/actions.editing.test.ts
+++ b/src/tests/unit/actions.editing.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { appState } from '$lib/state.svelte';
+import {
+  enterEditMode,
+  cancelEditMode,
+  confirmEditMode,
+  nudgeMarker,
+  computePreviewSegments,
+} from '$lib/actions';
+import { resetAppState } from '../helpers/reset-state';
+import type { Marker } from '$lib/types';
+
+function marker(id: string, position: number, kind: Marker['kind'] = 'start'): Marker {
+  return { id, position, kind };
+}
+
+// Flush multiple microtask ticks to allow nested async chains to settle
+async function flush() {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  resetAppState();
+});
+
+// ---------------------------------------------------------------------------
+// enterEditMode
+// ---------------------------------------------------------------------------
+
+describe('enterEditMode', () => {
+  it('sets editingMarkerId to the given marker id', () => {
+    appState.markers = [marker('m1', 3000)];
+    enterEditMode('m1');
+    expect(appState.editingMarkerId).toBe('m1');
+  });
+
+  it('copies the marker position into editingPositionMs', () => {
+    appState.markers = [marker('m1', 3000)];
+    enterEditMode('m1');
+    expect(appState.editingPositionMs).toBe(3000);
+  });
+
+  it('also selects the marker in the panel', () => {
+    appState.markers = [marker('m1', 3000)];
+    enterEditMode('m1');
+    expect(appState.selectedMarkerId).toBe('m1');
+  });
+
+  it('does nothing when the marker id is not found', () => {
+    appState.markers = [];
+    enterEditMode('nonexistent');
+    expect(appState.editingMarkerId).toBeNull();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('works when multiple markers exist — picks the correct one', () => {
+    appState.markers = [marker('m1', 1000), marker('m2', 5000)];
+    enterEditMode('m2');
+    expect(appState.editingMarkerId).toBe('m2');
+    expect(appState.editingPositionMs).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelEditMode
+// ---------------------------------------------------------------------------
+
+describe('cancelEditMode', () => {
+  it('clears editingMarkerId', () => {
+    appState.editingMarkerId = 'm1';
+    cancelEditMode();
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('resets editingPositionMs to 0', () => {
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    cancelEditMode();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('is a no-op when not in edit mode', () => {
+    appState.editingMarkerId = null;
+    appState.editingPositionMs = 0;
+    cancelEditMode();
+    expect(appState.editingMarkerId).toBeNull();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmEditMode
+// ---------------------------------------------------------------------------
+
+describe('confirmEditMode', () => {
+  it('does nothing when not in edit mode', async () => {
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    appState.editingMarkerId = null;
+    await confirmEditMode();
+    expect(handler).not.toHaveBeenCalledWith('move_marker', expect.anything());
+  });
+
+  it('calls move_marker with the correct id and newPositionMs', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await confirmEditMode();
+    expect(handler).toHaveBeenCalledWith('move_marker', { id: 'm1', newPositionMs: 5000 });
+  });
+
+  it('rounds a fractional position before sending', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000.7;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await confirmEditMode();
+    expect(handler).toHaveBeenCalledWith('move_marker', { id: 'm1', newPositionMs: 5001 });
+  });
+
+  it('updates the marker position in appState.markers', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 7000;
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    await confirmEditMode();
+    expect(appState.markers.find(m => m.id === 'm1')?.position).toBe(7000);
+  });
+
+  it('re-sorts markers by position after the update', async () => {
+    appState.markers = [marker('m1', 1000), marker('m2', 5000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 8000; // move m1 after m2
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    await confirmEditMode();
+    expect(appState.markers[0].id).toBe('m2');
+    expect(appState.markers[1].id).toBe('m1');
+  });
+
+  it('clears editingMarkerId on success', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    await confirmEditMode();
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('resets editingPositionMs to 0 on success', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    await confirmEditMode();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('calls validate_markers after moving', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await confirmEditMode();
+    expect(handler).toHaveBeenCalledWith('validate_markers', expect.anything());
+  });
+
+  it('sets appState.error when move_marker throws', async () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    mockIPC(() => { throw new Error('move failed'); });
+    await confirmEditMode();
+    expect(appState.error).toMatch('move failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nudgeMarker
+// ---------------------------------------------------------------------------
+
+describe('nudgeMarker', () => {
+  it('does nothing when no marker is being edited and none is selected', () => {
+    appState.durationMs = 60_000;
+    nudgeMarker(1);
+    expect(appState.editingMarkerId).toBeNull();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('auto-enters edit mode for the selected marker when not already editing', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.selectedMarkerId = 'm1';
+    appState.durationMs = 60_000;
+    nudgeMarker(1);
+    expect(appState.editingMarkerId).toBe('m1');
+  });
+
+  it('nudges right by nudgeStepMs (100ms)', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    nudgeMarker(1);
+    expect(appState.editingPositionMs).toBe(3100);
+  });
+
+  it('nudges left by nudgeStepMs (100ms)', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    nudgeMarker(-1);
+    expect(appState.editingPositionMs).toBe(2900);
+  });
+
+  it('clamps to 0 when nudging left past the start', () => {
+    appState.markers = [marker('m1', 50)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 50;
+    appState.durationMs = 60_000;
+    nudgeMarker(-1);
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('clamps to durationMs when nudging right past the end', () => {
+    appState.markers = [marker('m1', 59_950)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 59_950;
+    appState.durationMs = 60_000;
+    nudgeMarker(1);
+    expect(appState.editingPositionMs).toBe(60_000);
+  });
+
+  it('auto-enters and then nudges in one call (combined behaviour)', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.selectedMarkerId = 'm1';
+    appState.durationMs = 60_000;
+    nudgeMarker(-1);
+    // After auto-entry, editingPositionMs starts at 3000 then nudges -100
+    expect(appState.editingPositionMs).toBe(2900);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePreviewSegments
+// ---------------------------------------------------------------------------
+
+describe('computePreviewSegments', () => {
+  it('returns validated segments unchanged when not in edit mode', () => {
+    const segs = [{ startMs: 0, endMs: 1000, title: 'A' }];
+    appState.segments = segs;
+    appState.editingMarkerId = null;
+    expect(computePreviewSegments()).toEqual(segs);
+  });
+
+  it('falls back to partial segments when not editing and segments is null', () => {
+    appState.segments = null;
+    appState.editingMarkerId = null;
+    appState.markers = [marker('s1', 0, 'start'), marker('e1', 1000, 'end')];
+    appState.renameInputs = { s1: 'A' };
+    const result = computePreviewSegments();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ startMs: 0, endMs: 1000, title: 'A' });
+  });
+
+  it('swaps in editingPositionMs for the editing end marker', () => {
+    appState.markers = [marker('s1', 1000, 'start'), marker('e1', 5000, 'end')];
+    appState.renameInputs = { s1: 'Clip' };
+    appState.editingMarkerId = 'e1';
+    appState.editingPositionMs = 7000;
+    const result = computePreviewSegments();
+    expect(result).toHaveLength(1);
+    expect(result[0].endMs).toBe(7000);
+    expect(result[0].startMs).toBe(1000);
+  });
+
+  it('swaps in editingPositionMs for the editing start marker', () => {
+    appState.markers = [marker('s1', 1000, 'start'), marker('e1', 5000, 'end')];
+    appState.renameInputs = { s1: 'Clip' };
+    appState.editingMarkerId = 's1';
+    appState.editingPositionMs = 3000;
+    const result = computePreviewSegments();
+    expect(result).toHaveLength(1);
+    expect(result[0].startMs).toBe(3000);
+    expect(result[0].endMs).toBe(5000);
+  });
+
+  it('re-sorts markers after swapping so segment boundaries stay correct', () => {
+    // Move the start marker past the end marker — they should swap roles in output
+    appState.markers = [marker('s1', 1000, 'start'), marker('e1', 5000, 'end')];
+    appState.renameInputs = {};
+    appState.editingMarkerId = 's1';
+    appState.editingPositionMs = 7000; // now s1 is after e1
+    const result = computePreviewSegments();
+    // After sort, e1 (5000) comes before s1 (7000) — orphaned end produces no segment
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not mutate appState.markers', () => {
+    appState.markers = [marker('s1', 1000, 'start'), marker('e1', 5000, 'end')];
+    appState.editingMarkerId = 's1';
+    appState.editingPositionMs = 2000;
+    computePreviewSegments();
+    expect(appState.markers[0].position).toBe(1000);
+    expect(appState.markers[1].position).toBe(5000);
+  });
+
+  it('handles a startEnd marker being edited', () => {
+    appState.markers = [marker('b1', 3000, 'startEnd')];
+    appState.renameInputs = { b1: 'Beat' };
+    appState.editingMarkerId = 'b1';
+    appState.editingPositionMs = 6000;
+    const result = computePreviewSegments();
+    expect(result).toHaveLength(1);
+    expect(result[0].startMs).toBe(6000);
+    expect(result[0].endMs).toBe(6000);
+  });
+
+  it('returns empty array when editing leaves an unmatched start', () => {
+    appState.markers = [marker('s1', 1000, 'start')];
+    appState.editingMarkerId = 's1';
+    appState.editingPositionMs = 2000;
+    expect(computePreviewSegments()).toEqual([]);
+  });
+});

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -220,6 +220,98 @@ describe('handleKeydown — speed', () => {
   });
 });
 
+describe('handleKeydown — edit mode', () => {
+  it('[ auto-enters edit mode for the selected marker and nudges left', () => {
+    appState.markers = [{ id: 'm1', position: 3000, kind: 'start' }];
+    appState.selectedMarkerId = 'm1';
+    appState.durationMs = 60_000;
+    handleKeydown(keyEvent('['));
+    expect(appState.editingMarkerId).toBe('m1');
+    expect(appState.editingPositionMs).toBe(2900);
+  });
+
+  it('] auto-enters edit mode for the selected marker and nudges right', () => {
+    appState.markers = [{ id: 'm1', position: 3000, kind: 'start' }];
+    appState.selectedMarkerId = 'm1';
+    appState.durationMs = 60_000;
+    handleKeydown(keyEvent(']'));
+    expect(appState.editingMarkerId).toBe('m1');
+    expect(appState.editingPositionMs).toBe(3100);
+  });
+
+  it('[ nudges an already-editing marker without re-entering', () => {
+    appState.markers = [{ id: 'm1', position: 3000, kind: 'start' }];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    handleKeydown(keyEvent('['));
+    expect(appState.editingPositionMs).toBe(2900);
+  });
+
+  it('[ does nothing when no marker is selected and none is being edited', () => {
+    appState.selectedMarkerId = null;
+    appState.editingMarkerId = null;
+    appState.durationMs = 60_000;
+    handleKeydown(keyEvent('['));
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('] does nothing when no marker is selected and none is being edited', () => {
+    appState.selectedMarkerId = null;
+    appState.editingMarkerId = null;
+    appState.durationMs = 60_000;
+    handleKeydown(keyEvent(']'));
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('Escape cancels edit mode', () => {
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    handleKeydown(keyEvent('Escape'));
+    expect(appState.editingMarkerId).toBeNull();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('Escape is a no-op when not in edit mode', () => {
+    appState.editingMarkerId = null;
+    handleKeydown(keyEvent('Escape'));
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('Enter confirms edit mode and invokes move_marker', async () => {
+    appState.markers = [{ id: 'm1', position: 3000, kind: 'start' }];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    handleKeydown(keyEvent('Enter'));
+    await flush();
+    expect(handler).toHaveBeenCalledWith('move_marker', { id: 'm1', newPositionMs: 5000 });
+  });
+
+  it('Enter clears edit mode after confirming', async () => {
+    appState.markers = [{ id: 'm1', position: 3000, kind: 'start' }];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    handleKeydown(keyEvent('Enter'));
+    await flush();
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('Enter does nothing when not in edit mode', async () => {
+    appState.editingMarkerId = null;
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent('Enter'));
+    await flush();
+    expect(handler).not.toHaveBeenCalledWith('move_marker', expect.anything());
+  });
+});
+
 describe('handleKeydown — export', () => {
   it('Ctrl+e calls exportCsv', async () => {
     const handler = vi.fn(() => undefined);

--- a/src/tests/unit/actions.markers.test.ts
+++ b/src/tests/unit/actions.markers.test.ts
@@ -165,6 +165,26 @@ describe('deleteMarker', () => {
     await deleteMarker('m1');
     expect(appState.error).toMatch('delete failed');
   });
+
+  it('clears editingMarkerId when deleting the marker currently being edited', async () => {
+    appState.markers = [marker('m1', 1000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 2000;
+    mockIPC(() => undefined);
+    await deleteMarker('m1');
+    expect(appState.editingMarkerId).toBeNull();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('does not clear editingMarkerId when deleting a different marker', async () => {
+    appState.markers = [marker('m1', 1000), marker('m2', 2000)];
+    appState.editingMarkerId = 'm2';
+    appState.editingPositionMs = 3000;
+    mockIPC(() => undefined);
+    await deleteMarker('m1');
+    expect(appState.editingMarkerId).toBe('m2');
+    expect(appState.editingPositionMs).toBe(3000);
+  });
 });
 
 describe('renameSegment', () => {

--- a/src/tests/unit/actions.seeking.test.ts
+++ b/src/tests/unit/actions.seeking.test.ts
@@ -80,6 +80,23 @@ describe('seekToPrevMarker', () => {
     await seekToPrevMarker();
     expect(appState.positionMs).toBe(4949);
   });
+
+  it('sets selectedMarkerId to the marker seeked to', async () => {
+    mockIPC(() => undefined);
+    appState.markers = [marker('a', 1000), marker('b', 3000)];
+    appState.positionMs = 5000;
+    await seekToPrevMarker();
+    expect(appState.selectedMarkerId).toBe('b');
+  });
+
+  it('does not change selectedMarkerId when no previous marker exists', async () => {
+    mockIPC(() => undefined);
+    appState.markers = [marker('a', 8000)];
+    appState.positionMs = 1000;
+    appState.selectedMarkerId = null;
+    await seekToPrevMarker();
+    expect(appState.selectedMarkerId).toBeNull();
+  });
 });
 
 describe('seekToNextMarker', () => {
@@ -105,6 +122,23 @@ describe('seekToNextMarker', () => {
     appState.positionMs = 5000;
     await seekToNextMarker();
     expect(appState.positionMs).toBe(5000);
+  });
+
+  it('sets selectedMarkerId to the marker seeked to', async () => {
+    mockIPC(() => undefined);
+    appState.markers = [marker('a', 7000), marker('b', 9000)];
+    appState.positionMs = 5000;
+    await seekToNextMarker();
+    expect(appState.selectedMarkerId).toBe('a');
+  });
+
+  it('does not change selectedMarkerId when no next marker exists', async () => {
+    mockIPC(() => undefined);
+    appState.markers = [marker('a', 1000)];
+    appState.positionMs = 5000;
+    appState.selectedMarkerId = null;
+    await seekToNextMarker();
+    expect(appState.selectedMarkerId).toBeNull();
   });
 });
 

--- a/src/tests/unit/utils.test.ts
+++ b/src/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMs, kindLabel, SPEEDS } from '$lib/utils';
+import { formatMs, kindLabel, SPEEDS, parseTimeMs } from '$lib/utils';
 
 describe('formatMs', () => {
   it('formats zero as 00:00:00.000', () => {
@@ -47,6 +47,85 @@ describe('kindLabel', () => {
 
   it('returns Start+End for startEnd', () => {
     expect(kindLabel('startEnd')).toBe('Start+End');
+  });
+});
+
+describe('parseTimeMs', () => {
+  it('returns null for an empty string', () => {
+    expect(parseTimeMs('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(parseTimeMs('   ')).toBeNull();
+  });
+
+  it('parses plain whole seconds', () => {
+    expect(parseTimeMs('5')).toBe(5_000);
+  });
+
+  it('parses seconds greater than 59 as total seconds (no colon)', () => {
+    expect(parseTimeMs('90')).toBe(90_000);
+  });
+
+  it('parses decimal seconds — one ms digit is padded to three', () => {
+    expect(parseTimeMs('5.5')).toBe(5_500);
+  });
+
+  it('parses decimal seconds — two ms digits are padded to three', () => {
+    expect(parseTimeMs('5.50')).toBe(5_500);
+  });
+
+  it('parses decimal seconds — three ms digits exactly', () => {
+    expect(parseTimeMs('5.500')).toBe(5_500);
+  });
+
+  it('truncates milliseconds beyond three digits', () => {
+    expect(parseTimeMs('5.5009')).toBe(5_500);
+  });
+
+  it('parses MM:SS format', () => {
+    expect(parseTimeMs('1:30')).toBe(90_000);
+  });
+
+  it('parses MM:SS.m format (single ms digit)', () => {
+    expect(parseTimeMs('1:30.5')).toBe(90_500);
+  });
+
+  it('parses HH:MM:SS format', () => {
+    expect(parseTimeMs('1:30:00')).toBe(5_400_000);
+  });
+
+  it('parses HH:MM:SS.mmm — the canonical format produced by formatMs', () => {
+    expect(parseTimeMs('00:01:30.500')).toBe(90_500);
+  });
+
+  it('is the inverse of formatMs for arbitrary values', () => {
+    const ms = 12_345;
+    expect(parseTimeMs(formatMs(ms))).toBe(ms);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseTimeMs('  5  ')).toBe(5_000);
+  });
+
+  it('returns null for too many colon-separated parts', () => {
+    expect(parseTimeMs('1:2:3:4')).toBeNull();
+  });
+
+  it('returns null for seconds out of range in MM:SS (1:90)', () => {
+    expect(parseTimeMs('1:90')).toBeNull();
+  });
+
+  it('returns null for minutes out of range (1:60:00)', () => {
+    expect(parseTimeMs('1:60:00')).toBeNull();
+  });
+
+  it('returns null for non-numeric input', () => {
+    expect(parseTimeMs('abc')).toBeNull();
+  });
+
+  it('returns null for partially numeric input', () => {
+    expect(parseTimeMs('1:ab')).toBeNull();
   });
 });
 


### PR DESCRIPTION
- Add editing state (editingMarkerId, editingPositionMs, nudgeStepMs) to AppState
- Enter edit mode via the new pencil button on each marker row, or by pressing [ / ] with a marker selected
- Nudge the selected marker left/right in 100ms increments with [ and ]
- Type an exact time in flexible format (e.g. 5, 1:30, 1:30.5) and press Enter to save
- Waveform shows a ghost at the original position and a pulsing orange line at the draft position while editing
- SegmentPanel live-previews the segment layout while editing (dims to indicate unsaved state)
- Press Escape or click the pencil button again to cancel without saving
- Fix D/F (seek to prev/next marker) to also sync the selected marker in MarkerPanel
- Add Edit Marker section to the Keyboard Shortcuts panel