### PR TITLE
Add export dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The rust tests are written using cargo's built in testing suite. To run, use the
     cargo test 
 ```
 
-To generate a coverage report, run the following command (also from within the src-tauri directory)
+To generate a coverage report, run the following command (also from within the src-tauri directory). Note that for this to work, you will need to already have llvm-cov installed on your system. You can follow the setup instructions [here](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#installation) to install llvm-cov.
 
 ```bash
     cargo coverage

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -207,6 +207,8 @@ pub async fn validate_markers(state: State<'_, AppState>) -> Result<Vec<Segment>
 pub async fn export_audio_segments(
     app: AppHandle,
     state: State<'_, AppState>,
+    export_csv: bool, 
+    export_audio: bool, 
 ) -> Result<u32> {
     use tauri_plugin_dialog::DialogExt;
 
@@ -230,7 +232,7 @@ pub async fn export_audio_segments(
         .as_path()
         .ok_or_else(|| AppError::ValidationError("Invalid output directory path".into()))?;
 
-    export_segments(&app, &source_path, &segments, output_path).await
+    export_segments(&app, &source_path, &segments, output_path, export_csv, export_audio).await
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/export/segments.rs
+++ b/src-tauri/src/export/segments.rs
@@ -29,6 +29,8 @@ async fn export_segments_inner<F, Fut>(
     source_file: &str,
     segments: &[Segment],
     output_dir: &Path,
+    export_csv: bool, 
+    export_audio: bool,
     mut run_ffmpeg: F,
 ) -> Result<u32>
 where
@@ -65,18 +67,21 @@ where
             output_path.to_str().unwrap_or_default().to_string(),
         ];
 
-        let (success, stderr) = run_ffmpeg(args).await?;
-
-        if !success {
-            let stderr_str = String::from_utf8_lossy(&stderr).into_owned();
-            return Err(AppError::FfmpegFailed(filename, stderr_str));
+        if export_audio {
+            let (success, stderr) = run_ffmpeg(args).await?;
+            if !success {
+                let stderr_str = String::from_utf8_lossy(&stderr).into_owned();
+                return Err(AppError::FfmpegFailed(filename, stderr_str));
+            }
         }
     }
 
     // Write the CSV index file.
-    let csv_path = output_dir.join(format!("{}.csv", stem));
-    let csv_file = std::fs::File::create(csv_path)?;
-    write_csv(csv_file, segments)?;
+    if export_csv {
+        let csv_path = output_dir.join(format!("{}.csv", stem));
+        let csv_file = std::fs::File::create(csv_path)?;
+        write_csv(csv_file, segments)?;
+    }
 
     Ok(segments.len() as u32)
 }
@@ -92,6 +97,8 @@ pub async fn export_segments<R: Runtime>(
     source_file: &str,
     segments: &[Segment],
     output_dir: &Path,
+    export_csv: bool,
+    export_audio: bool,
 ) -> Result<u32> {
     let app = app.clone();
     let source_file = source_file.to_string();
@@ -99,6 +106,8 @@ pub async fn export_segments<R: Runtime>(
         &source_file,
         segments,
         output_dir,
+        export_csv, 
+        export_audio,
         move |args| {
             let app = app.clone();
             async move {
@@ -169,6 +178,8 @@ mod tests {
             "test.wav",
             &[],
             dir.path(),
+            true, 
+            true, 
             |_args| async { Ok((true, Vec::new())) },
         ));
         assert_eq!(result.unwrap(), 0);
@@ -183,6 +194,8 @@ mod tests {
             "track.mp3",
             &segments,
             dir.path(),
+            true, 
+            true, 
             |_args| async { Ok((true, Vec::new())) },
         ));
         assert_eq!(result.unwrap(), 2);
@@ -196,6 +209,8 @@ mod tests {
             "/path/to/my_track.wav",
             &segments,
             dir.path(),
+            true, 
+            true,
             |_args| async { Ok((true, Vec::new())) },
         ))
         .unwrap();
@@ -210,6 +225,8 @@ mod tests {
             "noext",
             &segments,
             dir.path(),
+            true, 
+            true,
             |args| {
                 // Verify the output filename ends with .mp3
                 let out_arg = args.last().unwrap().clone();
@@ -230,6 +247,8 @@ mod tests {
             "test.wav",
             &segments,
             dir.path(),
+            true, 
+            true, 
             |_args| async { Ok((false, b"codec error".to_vec())) },
         ));
         match result {
@@ -249,6 +268,8 @@ mod tests {
             "test.wav",
             &segments,
             dir.path(),
+            true, 
+            true,
             |_args| async {
                 Err(AppError::FfmpegNotFound("sidecar unavailable".into()))
             },
@@ -265,6 +286,8 @@ mod tests {
             "test.wav",
             &[],
             &nested,
+            true, 
+            true, 
             |_args| async { Ok((true, Vec::new())) },
         ))
         .unwrap();

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -3,8 +3,20 @@
 
   let { onOpenFile, onExportAudioSegments }: {
     onOpenFile: () => void;
-    onExportAudioSegments: () => void;
+    onExportAudioSegments: (exportCsv: boolean, exportAudio: boolean) => void;
   } = $props();
+
+  let exportDropdownOpen = $state(false);
+  let exportCsv = $state(true);
+  let exportAudio = $state(true);
+
+  function toggleDropdown() {
+    exportDropdownOpen = !exportDropdownOpen;
+  }
+
+  function closeDropdown() {
+    exportDropdownOpen = false;
+  }
 </script>
 
 <header class="header">
@@ -22,14 +34,42 @@
       </svg>
       Open File
     </button>
-    <button class="btn-export" onclick={onExportAudioSegments}>
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14">
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-        <polyline points="7 10 12 15 17 10"/>
-        <line x1="12" y1="15" x2="12" y2="3"/>
-      </svg>
-      Export 
-    </button>
+    <div class="export-wrapper">
+      <button class="btn-export" onclick={toggleDropdown}>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+          <polyline points="7 10 12 15 17 10"/>
+          <line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+        Export
+        <svg class="chevron" class:open={exportDropdownOpen} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </button>
+
+      {#if exportDropdownOpen}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <div class="export-backdrop" role="presentation" onclick={closeDropdown}></div>
+        <div class="export-dropdown">
+          <label class="export-option">
+            <input type="checkbox" bind:checked={exportCsv} />
+            <span>CSV</span>
+          </label>
+          <label class="export-option">
+            <input type="checkbox" bind:checked={exportAudio} />
+            <span>Audio Segments</span>
+          </label>
+          <hr class="export-divider" />
+          <button
+            class="export-go"
+            disabled={(!exportCsv && !exportAudio) || !appState.segments?.length}
+            onclick={() => { onExportAudioSegments(exportCsv, exportAudio); closeDropdown(); }}
+          >
+            Export
+          </button>
+        </div>
+      {/if}
+    </div>
   </div>
 </header>
 
@@ -86,4 +126,78 @@
   }
 
   .btn-export:hover { background: #263548; border-color: #4d6a8a; }
+
+  .chevron { transition: transform 0.15s; }
+  .chevron.open { transform: rotate(180deg); }
+
+  .export-wrapper {
+    position: relative;
+  }
+
+  .export-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+  }
+
+  .export-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 11;
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 8px;
+    min-width: 160px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .export-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 6px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 13px;
+    color: #e2e8f0;
+  }
+
+  .export-option:hover { background: #1e2a3a; }
+
+  .export-option input[type="checkbox"] {
+    accent-color: #4d6a8a;
+    width: 14px;
+    height: 14px;
+    cursor: pointer;
+  }
+
+  .export-divider {
+    border: none;
+    border-top: 1px solid #21262d;
+    margin: 4px 0;
+  }
+
+  .export-go {
+    width: 100%;
+    padding: 6px 10px;
+    background: #1e2a3a;
+    color: #e2e8f0;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .export-go:hover:not(:disabled) { background: #263548; border-color: #4d6a8a; }
+
+  .export-go:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 </style>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -407,10 +407,10 @@ export async function exportCsv() {
   }
 }
 
-export async function exportAudioSegments() {
+export async function exportAudioSegments(exportCsv: boolean, exportAudio: boolean) {
   try {
     appState.error = null;
-    await invoke('export_audio_segments');
+    await invoke('export_audio_segments', {exportCsv, exportAudio});
   } catch (e) {
     appState.error = String(e);
   }


### PR DESCRIPTION
This PR addresses #21 . The export button is now a drop down that exposes checkboxes for CSV and Audio Segments. The user can select one or both but if neither are selected then the export button within the drop down is disabled and grayed out for the user. The export button within the drop down is also disabled if the user has not yet added any segments to export. 

The tests for the rust backend have been re-benched to account for this change. 