### PR TITLE
Add CSV Import and Header Error Alert

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -220,6 +220,35 @@ pub async fn import_csv(
     let file = std::fs::File::open(path.to_string())?;
     let segments = import_markers_from_reader(file)?;
 
+    // Validate that all marker positions fit within the loaded audio file.
+    {
+        let engine_guard = state.engine.lock();
+        let duration_ms = engine_guard
+            .as_ref()
+            .ok_or(AppError::NoFileLoaded)?
+            .metadata
+            .duration_ms;
+
+        for seg in &segments {
+            if seg.start_ms > duration_ms {
+                return Err(AppError::ValidationError(format!(
+                    "Segment '{}' start ({}) exceeds audio duration ({})",
+                    seg.title,
+                    crate::export::csv::ms_to_timestamp(seg.start_ms),
+                    crate::export::csv::ms_to_timestamp(duration_ms),
+                )));
+            }
+            if seg.end_ms > duration_ms {
+                return Err(AppError::ValidationError(format!(
+                    "Segment '{}' end ({}) exceeds audio duration ({})",
+                    seg.title,
+                    crate::export::csv::ms_to_timestamp(seg.end_ms),
+                    crate::export::csv::ms_to_timestamp(duration_ms),
+                )));
+            }
+        }
+    }
+
     let mut store = state.markers.lock();
     store.clear();
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 
 use crate::audio::{AudioEngine, FileMetadata};
 use crate::error::{AppError, Result};
+use crate::export::csv::import_markers_from_reader;
 use crate::export::export_segments;
 use crate::markers::{Marker, MarkerKind, Segment};
 use crate::state::AppState;
@@ -194,6 +195,46 @@ pub async fn list_markers(state: State<'_, AppState>) -> Result<Vec<Marker>> {
 #[tauri::command]
 pub async fn validate_markers(state: State<'_, AppState>) -> Result<Vec<Segment>> {
     state.markers.lock().to_segments()
+}
+
+// ---------------------------------------------------------------------------
+// CSV import
+// ---------------------------------------------------------------------------
+
+/// Open a CSV file dialog, parse the selected file, replace all current markers
+/// with the imported segments, and return the new marker list.
+#[tauri::command]
+pub async fn import_csv(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Vec<Marker>> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("CSV", &["csv"])
+        .blocking_pick_file()
+        .ok_or(AppError::DialogCancelled)?;
+
+    let file = std::fs::File::open(path.to_string())?;
+    let segments = import_markers_from_reader(file)?;
+
+    let mut store = state.markers.lock();
+    store.clear();
+
+    for seg in &segments {
+        if seg.start_ms == seg.end_ms {
+            let m = store.add(seg.start_ms, MarkerKind::StartEnd);
+            store.rename_segment(m.id, seg.title.clone())?;
+        } else {
+            let start = store.add(seg.start_ms, MarkerKind::Start);
+            store.rename_segment(start.id, seg.title.clone())?;
+            store.add(seg.end_ms, MarkerKind::End);
+        }
+    }
+
+    Ok(store.list().to_vec())
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/export/csv.rs
+++ b/src-tauri/src/export/csv.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{AppError, Result};
 use crate::markers::Segment;
 
 /// Format a millisecond timestamp as `HH:MM:SS.mmm`.
@@ -28,6 +28,63 @@ pub fn write_csv<W: std::io::Write>(writer: W, segments: &[Segment]) -> Result<(
     }
     wtr.flush()?;
     Ok(())
+}
+
+/// Parse a timestamp string `HH:MM:SS.mmm` into milliseconds.
+/// Returns `None` if the format is invalid.
+pub fn parse_timestamp(s: &str) -> Option<u64> {
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let hours: u64 = parts[0].parse().ok()?;
+    let minutes: u64 = parts[1].parse().ok()?;
+    let sec_parts: Vec<&str> = parts[2].splitn(2, '.').collect();
+    if sec_parts.len() != 2 {
+        return None;
+    }
+    let seconds: u64 = sec_parts[0].parse().ok()?;
+    let millis: u64 = sec_parts[1].parse().ok()?;
+    Some((hours * 3_600 + minutes * 60 + seconds) * 1_000 + millis)
+}
+
+/// Read CSV rows (no header) from `reader` and return a list of `Segment`s.
+/// Expected columns: Index, Start Timestamp, End Timestamp, Segment Title.
+pub fn import_markers_from_reader<R: std::io::Read>(reader: R) -> Result<Vec<Segment>> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .from_reader(reader);
+
+    let mut segments = Vec::new();
+
+    for (row_idx, result) in rdr.records().enumerate() {
+        let record = result?;
+        if record.len() < 4 {
+            return Err(AppError::ValidationError(format!(
+                "Row {}: expected 4 fields, got {}",
+                row_idx + 1,
+                record.len()
+            )));
+        }
+        let start_ms = parse_timestamp(record[1].trim()).ok_or_else(|| {
+            AppError::ValidationError(format!(
+                "Row {}: invalid start timestamp {:?}",
+                row_idx + 1,
+                &record[1]
+            ))
+        })?;
+        let end_ms = parse_timestamp(record[2].trim()).ok_or_else(|| {
+            AppError::ValidationError(format!(
+                "Row {}: invalid end timestamp {:?}",
+                row_idx + 1,
+                &record[2]
+            ))
+        })?;
+        let title = record[3].trim().to_string();
+        segments.push(Segment { start_ms, end_ms, title });
+    }
+
+    Ok(segments)
 }
 
 #[cfg(test)]
@@ -120,5 +177,117 @@ mod tests {
         }
         let result = write_csv(FailWriter, &[seg(0, 1000, "test")]);
         assert!(result.is_err());
+    }
+
+    // --- parse_timestamp tests ---
+
+    #[test]
+    fn parse_timestamp_zero() {
+        assert_eq!(parse_timestamp("00:00:00.000"), Some(0));
+    }
+
+    #[test]
+    fn parse_timestamp_one_second() {
+        assert_eq!(parse_timestamp("00:00:01.000"), Some(1_000));
+    }
+
+    #[test]
+    fn parse_timestamp_one_minute() {
+        assert_eq!(parse_timestamp("00:01:00.000"), Some(60_000));
+    }
+
+    #[test]
+    fn parse_timestamp_one_hour() {
+        assert_eq!(parse_timestamp("01:00:00.000"), Some(3_600_000));
+    }
+
+    #[test]
+    fn parse_timestamp_combined() {
+        assert_eq!(parse_timestamp("01:01:01.500"), Some(3_661_500));
+    }
+
+    #[test]
+    fn parse_timestamp_invalid_missing_dot() {
+        assert_eq!(parse_timestamp("00:00:01"), None);
+    }
+
+    #[test]
+    fn parse_timestamp_invalid_non_numeric() {
+        assert_eq!(parse_timestamp("xx:00:00.000"), None);
+    }
+
+    #[test]
+    fn parse_timestamp_invalid_wrong_parts() {
+        assert_eq!(parse_timestamp("00:00"), None);
+    }
+
+    #[test]
+    fn parse_timestamp_roundtrips() {
+        assert_eq!(parse_timestamp(&ms_to_timestamp(3_661_500)), Some(3_661_500));
+    }
+
+    // --- import_markers_from_reader tests ---
+
+    #[test]
+    fn import_single_row_produces_one_segment() {
+        let csv = "1,00:00:00.000,00:00:05.000,My Segment\n";
+        let result = import_markers_from_reader(csv.as_bytes()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start_ms, 0);
+        assert_eq!(result[0].end_ms, 5_000);
+        assert_eq!(result[0].title, "My Segment");
+    }
+
+    #[test]
+    fn import_multiple_rows_preserves_order() {
+        let csv = "1,00:00:00.000,00:00:05.000,First\n2,00:00:06.000,00:00:10.000,Second\n";
+        let result = import_markers_from_reader(csv.as_bytes()).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].title, "First");
+        assert_eq!(result[1].title, "Second");
+    }
+
+    #[test]
+    fn import_row_with_comma_in_title() {
+        let csv = "1,00:00:00.000,00:00:05.000,\"Hello, World\"\n";
+        let result = import_markers_from_reader(csv.as_bytes()).unwrap();
+        assert_eq!(result[0].title, "Hello, World");
+    }
+
+    #[test]
+    fn import_empty_reader_returns_empty_vec() {
+        let result = import_markers_from_reader("".as_bytes()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn import_invalid_start_timestamp_returns_error() {
+        let csv = "1,xx:xx:xx.xxx,00:00:05.000,Test\n";
+        let result = import_markers_from_reader(csv.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn import_invalid_end_timestamp_returns_error() {
+        let csv = "1,00:00:00.000,xx:xx:xx.xxx,Test\n";
+        let result = import_markers_from_reader(csv.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn import_roundtrips_write_then_read() {
+        let original = vec![
+            seg(0, 5_000, "001 Segment"),
+            seg(6_000, 10_000, "002 Segment"),
+        ];
+        let mut buf: Vec<u8> = Vec::new();
+        write_csv(&mut buf, &original).unwrap();
+        let imported = import_markers_from_reader(buf.as_slice()).unwrap();
+        assert_eq!(imported.len(), original.len());
+        for (imp, orig) in imported.iter().zip(original.iter()) {
+            assert_eq!(imp.start_ms, orig.start_ms);
+            assert_eq!(imp.end_ms, orig.end_ms);
+            assert_eq!(imp.title, orig.title);
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
             commands::rename_segment,
             commands::list_markers,
             commands::validate_markers,
+            commands::import_csv,
             commands::export_audio_segments,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/markers/store.rs
+++ b/src-tauri/src/markers/store.rs
@@ -85,6 +85,12 @@ impl MarkerStore {
         Ok(())
     }
 
+    /// Remove all markers and titles.
+    pub fn clear(&mut self) {
+        self.markers.clear();
+        self.titles.clear();
+    }
+
     /// Return all markers in sorted order.
     pub fn list(&self) -> &[Marker] {
         &self.markers
@@ -203,5 +209,16 @@ mod tests {
         let mut store = MarkerStore::new();
         let result = store.move_marker(Uuid::new_v4(), 1000);
         assert!(matches!(result, Err(crate::error::AppError::MarkerNotFound(_))));
+    }
+
+    #[test]
+    fn clear_removes_all_markers_and_titles() {
+        let mut store = MarkerStore::new();
+        let s = store.add(0, MarkerKind::Start);
+        store.add(5000, MarkerKind::End);
+        store.rename_segment(s.id, "My Segment".into()).unwrap();
+        store.clear();
+        assert!(store.list().is_empty());
+        assert!(store.titles.is_empty());
     }
 }

--- a/src/components/ErrorAlert.svelte
+++ b/src/components/ErrorAlert.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { appState } from '$lib/state.svelte';
+
+  function dismiss() {
+    appState.error = null;
+  }
+</script>
+
+{#if appState.error}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div class="backdrop" role="presentation" onclick={dismiss}></div>
+  <div class="alert" role="alertdialog" aria-modal="true" aria-labelledby="alert-title">
+    <div class="alert-icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="22" height="22">
+        <circle cx="12" cy="12" r="10"/>
+        <line x1="12" y1="8" x2="12" y2="12"/>
+        <line x1="12" y1="16" x2="12.01" y2="16"/>
+      </svg>
+    </div>
+    <div class="alert-body">
+      <p id="alert-title" class="alert-title">Error</p>
+      <p class="alert-message">{appState.error}</p>
+    </div>
+    <button class="btn-dismiss" onclick={dismiss}>OK</button>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 100;
+  }
+
+  .alert {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 101;
+    background: #161b22;
+    border: 1px solid #f87171;
+    border-radius: 10px;
+    padding: 20px 24px;
+    min-width: 320px;
+    max-width: 520px;
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  }
+
+  .alert-icon {
+    color: #f87171;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .alert-body {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .alert-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: #f87171;
+    margin-bottom: 6px;
+  }
+
+  .alert-message {
+    font-size: 13px;
+    color: #e2e8f0;
+    line-height: 1.5;
+    word-break: break-word;
+  }
+
+  .btn-dismiss {
+    flex-shrink: 0;
+    padding: 6px 18px;
+    background: #1e2a3a;
+    color: #e2e8f0;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    margin-top: 2px;
+  }
+
+  .btn-dismiss:hover {
+    background: #263548;
+    border-color: #4d6a8a;
+  }
+</style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -26,9 +26,6 @@
     <p class="app-sub">Precision audio/video segmentation tool</p>
   </div>
   <div class="header-right">
-    {#if appState.error}
-      <span class="error-badge">{appState.error}</span>
-    {/if}
     <button class="btn-export" onclick={onOpenFile}>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14">
         <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
@@ -108,15 +105,6 @@
     display: flex;
     align-items: center;
     gap: 10px;
-  }
-
-  .error-badge {
-    font-size: 11px;
-    color: #f87171;
-    max-width: 300px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .btn-export {

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
 
-  let { onOpenFile, onExportAudioSegments }: {
+  let { onOpenFile, onImportCsv, onExportAudioSegments }: {
     onOpenFile: () => void;
+    onImportCsv: () => void;
     onExportAudioSegments: (exportCsv: boolean, exportAudio: boolean) => void;
   } = $props();
 
@@ -33,6 +34,14 @@
         <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
       </svg>
       Open File
+    </button>
+    <button class="btn-export" onclick={onImportCsv}>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <polyline points="17 8 12 3 7 8"/>
+        <line x1="12" y1="3" x2="12" y2="15"/>
+      </svg>
+      Import CSV
     </button>
     <div class="export-wrapper">
       <button class="btn-export" onclick={toggleDropdown}>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -415,3 +415,23 @@ export async function exportAudioSegments(exportCsv: boolean, exportAudio: boole
     appState.error = String(e);
   }
 }
+
+export async function importCsv() {
+  try {
+    appState.error = null;
+    const markers = await invoke<Marker[]>('import_csv');
+    appState.markers = markers.sort((a, b) => a.position - b.position);
+    appState.renameInputs = Object.fromEntries(
+      markers.filter(m => m.kind !== 'end').map(m => [m.id, ''])
+    );
+    appState.selectedMarkerId = null;
+    appState.editingMarkerId = null;
+    appState.editingPositionMs = 0;
+    appState.unkindedMarkers = new Set();
+    await revalidate();
+  } catch (e) {
+    if (String(e) !== 'Dialog cancelled') {
+      appState.error = String(e);
+    }
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { appState } from '$lib/state.svelte';
   import {
     stopPolling, stopRaf, handleKeydown,
-    openFile, togglePlay, setSpeed, handleLoop,
+    openFile, importCsv, togglePlay, setSpeed, handleLoop,
     addMarkerNoKind, addMarkerAt, deleteMarker,
     renameSegment, exportAudioSegments,
     stepBack, stepFwd,
@@ -34,6 +34,7 @@
 {:else}
   <div class="app">
     <Header onOpenFile={openFile}
+            onImportCsv={importCsv}
             onExportAudioSegments={exportAudioSegments}
     />
     <WaveformDisplay />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
   import MarkerPanel from '../components/MarkerPanel.svelte';
   import SegmentPanel from '../components/SegmentPanel.svelte';
   import ShortcutsPanel from '../components/ShortcutsPanel.svelte';
+  import ErrorAlert from '../components/ErrorAlert.svelte';
 
   onMount(() => {
     document.addEventListener('keydown', handleKeydown);
@@ -28,6 +29,8 @@
     if (appState.wavesurfer) appState.wavesurfer.destroy();
   });
 </script>
+
+<ErrorAlert />
 
 {#if !appState.metadata}
   <WelcomeScreen onOpenFile={openFile} />

--- a/src/tests/unit/actions.import.test.ts
+++ b/src/tests/unit/actions.import.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockIPC } from '@tauri-apps/api/mocks';
+import { appState } from '$lib/state.svelte';
+import { importCsv } from '$lib/actions';
+import { resetAppState } from '../helpers/reset-state';
+import type { Marker, Segment } from '$lib/types';
+
+function marker(id: string, position: number, kind: Marker['kind'] = 'start'): Marker {
+  return { id, position, kind };
+}
+
+function segment(startMs: number, endMs: number, title: string): Segment {
+  return { startMs, endMs, title };
+}
+
+beforeEach(() => {
+  resetAppState();
+});
+
+describe('importCsv', () => {
+  it('sets appState.markers sorted by position', async () => {
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'import_csv') return [marker('m2', 5000, 'end'), marker('m1', 0, 'start')];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await importCsv();
+    expect(appState.markers[0].id).toBe('m1');
+    expect(appState.markers[1].id).toBe('m2');
+  });
+
+  it('calls validate_markers after import', async () => {
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'import_csv') return [marker('m1', 0, 'start'), marker('m2', 1000, 'end')];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await importCsv();
+    expect(handler).toHaveBeenCalledWith('validate_markers', expect.anything());
+  });
+
+  it('sets appState.segments from validate_markers result', async () => {
+    const segs = [segment(0, 1000, 'Imported')];
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'import_csv') return [marker('m1', 0, 'start'), marker('m2', 1000, 'end')];
+      if (cmd === 'validate_markers') return segs;
+      return undefined;
+    });
+    mockIPC(handler);
+    await importCsv();
+    expect(appState.segments).toEqual(segs);
+  });
+
+  it('resets selectedMarkerId to null', async () => {
+    appState.selectedMarkerId = 'old';
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return [];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.selectedMarkerId).toBeNull();
+  });
+
+  it('resets editingMarkerId to null', async () => {
+    appState.editingMarkerId = 'old';
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return [];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('resets editingPositionMs to 0', async () => {
+    appState.editingPositionMs = 999;
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return [];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('resets unkindedMarkers to empty set', async () => {
+    appState.unkindedMarkers = new Set(['old']);
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return [];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.unkindedMarkers.size).toBe(0);
+  });
+
+  it('sets renameInputs only for non-end markers', async () => {
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'import_csv') return [
+        marker('s1', 0, 'start'),
+        marker('e1', 1000, 'end'),
+        marker('b1', 2000, 'startEnd'),
+      ];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await importCsv();
+    expect(appState.renameInputs['s1']).toBe('');
+    expect(appState.renameInputs['b1']).toBe('');
+    expect(appState.renameInputs['e1']).toBeUndefined();
+  });
+
+  it('does not set appState.error when dialog is cancelled', async () => {
+    mockIPC(() => { throw 'Dialog cancelled'; });
+    await importCsv();
+    expect(appState.error).toBeNull();
+  });
+
+  it('sets appState.error on other failures', async () => {
+    mockIPC(() => { throw new Error('parse error'); });
+    await importCsv();
+    expect(appState.error).toMatch('parse error');
+  });
+
+  it('clears appState.error before invoking', async () => {
+    appState.error = 'old error';
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return [];
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.error).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR addresses #22 by adding an import CSV button in the top right of the main page. The user can select an existing CSV to import previously created markers on top of the audio file. The CSV file is parsed and an alert is presented to the user if it is malformed in any way. There is also validation that all of the imported markers fit within the width of the current audio file