### PR TITLE
Add waveform zoom in/out with keyboard shortcuts and test coverage

### DIFF
--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -25,6 +25,10 @@
     </div>
     <div class="shortcut-row"><kbd>1–5</kbd><span>Playback Speed</span></div>
 
+    <div class="shortcut-subheading">Waveform Zoom</div>
+    <div class="shortcut-row"><kbd>-</kbd><span>Zoom out</span></div>
+    <div class="shortcut-row"><kbd>+</kbd><span>Zoom in</span></div>
+
     <div class="shortcut-subheading">Add Marker</div>
     <div class="shortcut-row"><kbd>S</kbd><span>Start</span></div>
     <div class="shortcut-row"><kbd>E</kbd><span>End</span></div>

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -2,15 +2,23 @@
   import { invoke, convertFileSrc } from '@tauri-apps/api/core';
   import WaveSurfer from 'wavesurfer.js';
   import { appState } from '$lib/state.svelte';
-  import { kindLabel, formatMs } from '$lib/utils';
+  import { kindLabel, formatMs, ZOOM_LEVELS } from '$lib/utils';
 
-  let waveformEl = $state<HTMLDivElement | null>(null);
+  let waveformEl     = $state<HTMLDivElement | null>(null);
+  let waveformWrapEl = $state<HTMLDivElement | null>(null);
+
+  // Expose the wrap element so external code can scroll it if needed
+  $effect(() => { appState.waveformWrapEl = waveformWrapEl; });
 
   // Initialize (or reinitialize) WaveSurfer whenever the loaded file changes.
   // The cleanup function runs on component destroy or before re-running.
   $effect(() => {
     const filePath = appState.metadata?.filePath;
     if (!filePath || !waveformEl) return;
+
+    // Reset zoom and scroll when a new file is loaded
+    appState.zoomLevel = 1;
+    if (waveformWrapEl) waveformWrapEl.scrollLeft = 0;
 
     const ws = WaveSurfer.create({
       container: waveformEl,
@@ -34,6 +42,29 @@
     };
   });
 
+  // Auto-scroll to keep playhead centered during playback
+  $effect(() => {
+    const pos = appState.positionMs; // reactive dependency
+    if (!waveformWrapEl || appState.waveformDragging || appState.zoomLevel <= 1) return;
+    if (!appState.isPlaying) return;
+    const pct = appState.durationMs > 0 ? pos / appState.durationMs : 0;
+    const total = waveformWrapEl.scrollWidth;
+    const visible = waveformWrapEl.clientWidth;
+    waveformWrapEl.scrollLeft = Math.max(0, pct * total - visible / 2);
+  });
+
+  // ── Zoom controls ──────────────────────────────────────────────────────
+
+  function zoomIn() {
+    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
+    if (i < ZOOM_LEVELS.length - 1) appState.zoomLevel = ZOOM_LEVELS[i + 1];
+  }
+
+  function zoomOut() {
+    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
+    if (i > 0) appState.zoomLevel = ZOOM_LEVELS[i - 1];
+  }
+
   // ── Waveform drag seeking ──────────────────────────────────────────────
   // We own pointer events on the container so the playhead moves in real-time.
 
@@ -41,6 +72,8 @@
 
   function waveformPosFromEvent(e: PointerEvent): number {
     if (!waveformEl) return 0;
+    // getBoundingClientRect returns screen coords accounting for scroll offset,
+    // so this calculation is correct even when the waveform is zoomed and scrolled.
     const rect = waveformEl.getBoundingClientRect();
     const pct  = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
     return pct * appState.durationMs;
@@ -88,8 +121,25 @@
   }
 </script>
 
+<div class="zoom-controls">
+  <button
+    class="zoom-btn"
+    onclick={zoomOut}
+    disabled={!appState.metadata || appState.zoomLevel <= 1}
+    title="Zoom out"
+  >−</button>
+  <span class="zoom-label">{appState.zoomLevel}x</span>
+  <button
+    class="zoom-btn"
+    onclick={zoomIn}
+    disabled={!appState.metadata || appState.zoomLevel >= 16}
+    title="Zoom in"
+  >+</button>
+</div>
+
 <div
   class="waveform-wrap"
+  bind:this={waveformWrapEl}
   role="slider"
   aria-label="Playback position"
   aria-valuemin={0}
@@ -101,37 +151,75 @@
   onpointerup={handlePointerUp}
   onpointercancel={handlePointerUp}
 >
-  <div class="waveform-inner" bind:this={waveformEl}></div>
-  <!-- Marker overlays -->
-  {#each appState.markers as m (m.id)}
-    {@const isEditing = appState.editingMarkerId === m.id}
-    {@const draftPct  = appState.durationMs > 0 ? (appState.editingPositionMs / appState.durationMs) * 100 : 0}
-    {@const origPct   = appState.durationMs > 0 ? (m.position / appState.durationMs) * 100 : 0}
-    {#if isEditing}
-      <!-- Ghost at original position -->
-      <div
-        class="marker-line marker-ghost"
-        style="left: {origPct}%"
-        title="Original — {formatMs(m.position)}"
-      ></div>
-      <!-- Draft at new position -->
-      <div
-        class="marker-line marker-editing"
-        style="left: {draftPct}%"
-        title="{kindLabel(m.kind)} — {formatMs(appState.editingPositionMs)}"
-      ></div>
-    {:else}
-      <div
-        class="marker-line"
-        class:marker-selected={appState.selectedMarkerId === m.id}
-        style="left: {origPct}%"
-        title="{kindLabel(m.kind)} — {formatMs(m.position)}"
-      ></div>
-    {/if}
-  {/each}
+  <div class="waveform-scroll" style="width: {appState.zoomLevel * 100}%">
+    <div class="waveform-inner" bind:this={waveformEl}></div>
+    <!-- Marker overlays — left: pct% is relative to waveform-scroll, same width as the waveform -->
+    {#each appState.markers as m (m.id)}
+      {@const isEditing = appState.editingMarkerId === m.id}
+      {@const draftPct  = appState.durationMs > 0 ? (appState.editingPositionMs / appState.durationMs) * 100 : 0}
+      {@const origPct   = appState.durationMs > 0 ? (m.position / appState.durationMs) * 100 : 0}
+      {#if isEditing}
+        <!-- Ghost at original position -->
+        <div
+          class="marker-line marker-ghost"
+          style="left: {origPct}%"
+          title="Original — {formatMs(m.position)}"
+        ></div>
+        <!-- Draft at new position -->
+        <div
+          class="marker-line marker-editing"
+          style="left: {draftPct}%"
+          title="{kindLabel(m.kind)} — {formatMs(appState.editingPositionMs)}"
+        ></div>
+      {:else}
+        <div
+          class="marker-line"
+          class:marker-selected={appState.selectedMarkerId === m.id}
+          style="left: {origPct}%"
+          title="{kindLabel(m.kind)} — {formatMs(m.position)}"
+        ></div>
+      {/if}
+    {/each}
+  </div>
 </div>
 
 <style>
+  .zoom-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 12px;
+    background: #0f1419;
+    border-bottom: 1px solid #21262d;
+  }
+
+  .zoom-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: #1e2a3a;
+    border: 1px solid #30363d;
+    border-radius: 5px;
+    color: #8b949e;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .zoom-btn:hover:not(:disabled) { color: #e2e8f0; border-color: #4d6a8a; }
+  .zoom-btn:disabled { opacity: 0.35; cursor: default; }
+
+  .zoom-label {
+    font-size: 11px;
+    color: #8b949e;
+    min-width: 28px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
   .waveform-wrap {
     position: relative;
     width: 100%;
@@ -139,11 +227,19 @@
     flex-shrink: 0;
     background: #0d1117;
     border-bottom: 1px solid #21262d;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .waveform-scroll {
+    position: relative;
+    height: 100%;
+    min-width: 100%;
   }
 
   .waveform-inner {
     width: 100%;
+    height: 100%;
   }
 
   .marker-line {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { appState } from './state.svelte';
-import { SPEEDS } from './utils';
+import { SPEEDS, ZOOM_LEVELS } from './utils';
 import type { FileMetadata, PlaybackPosition, Marker, Segment, MarkerKind } from './types';
 
 // ── Position polling + interpolation ─────────────────────────────────────
@@ -116,6 +116,14 @@ export function handleKeydown(e: KeyboardEvent) {
     e.preventDefault();
     const idx = parseInt(e.key) - 1;
     if (SPEEDS[idx] !== undefined) setSpeed(SPEEDS[idx]);
+  } else if (e.key === '-') {
+    e.preventDefault();
+    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
+    if (i > 0) appState.zoomLevel = ZOOM_LEVELS[i - 1];
+  } else if (e.key === '+' || e.key === '=') {
+    e.preventDefault();
+    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
+    if (i < ZOOM_LEVELS.length - 1) appState.zoomLevel = ZOOM_LEVELS[i + 1];
   }
 }
 
@@ -129,6 +137,14 @@ export async function seekTo(ms: number) {
     appState.syncWallTime   = performance.now();
     if (appState.wavesurfer && appState.durationMs > 0) {
       appState.wavesurfer.setTime(ms / 1000);
+    }
+    // Scroll waveform to keep the new position visible when zoomed
+    const wrap = appState.waveformWrapEl;
+    if (wrap && appState.zoomLevel > 1 && appState.durationMs > 0) {
+      const pct     = ms / appState.durationMs;
+      const total   = wrap.scrollWidth;
+      const visible = wrap.clientWidth;
+      wrap.scrollLeft = Math.max(0, pct * total - visible / 2);
     }
   } catch (e) {
     appState.error = String(e);

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -29,6 +29,10 @@ class AppState {
 
   // ── WaveSurfer instance (non-reactive, set by WaveformDisplay) ────────
   wavesurfer: WaveSurfer | null = null;
+
+  // ── Zoom (reactive) + scroll container ref (non-reactive) ─────────────
+  zoomLevel = $state(1);  // multiplier: 1 | 2 | 4 | 8 | 16
+  waveformWrapEl: HTMLDivElement | null = null;
 }
 
 export const appState = new AppState();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,7 @@ export function kindLabel(kind: MarkerKind): string {
 }
 
 export const SPEEDS = [0.5, 0.75, 1, 1.5, 2];
+export const ZOOM_LEVELS = [1, 2, 4, 8, 16];
 
 // Parses a flexible time string back to milliseconds. Accepted formats:
 //   "5"          → 5 seconds

--- a/src/tests/helpers/reset-state.ts
+++ b/src/tests/helpers/reset-state.ts
@@ -21,4 +21,6 @@ export function resetAppState() {
   appState.syncPositionMs   = 0;
   appState.syncWallTime     = 0;
   appState.wavesurfer       = null;
+  appState.zoomLevel        = 1;
+  appState.waveformWrapEl   = null;
 }

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -312,6 +312,56 @@ describe('handleKeydown — edit mode', () => {
   });
 });
 
+describe('handleKeydown — zoom', () => {
+  it('- key decrements zoom level', () => {
+    appState.zoomLevel = 4;
+    handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBe(2);
+  });
+
+  it('- key does nothing when already at minimum zoom (1)', () => {
+    appState.zoomLevel = 1;
+    handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBe(1);
+  });
+
+  it('+ key increments zoom level', () => {
+    appState.zoomLevel = 2;
+    handleKeydown(keyEvent('+'));
+    expect(appState.zoomLevel).toBe(4);
+  });
+
+  it('= key also increments zoom level (unshifted + key)', () => {
+    appState.zoomLevel = 2;
+    handleKeydown(keyEvent('='));
+    expect(appState.zoomLevel).toBe(4);
+  });
+
+  it('+ key does nothing when already at maximum zoom (16)', () => {
+    appState.zoomLevel = 16;
+    handleKeydown(keyEvent('+'));
+    expect(appState.zoomLevel).toBe(16);
+  });
+
+  it('stepping through all levels with + reaches maximum', () => {
+    appState.zoomLevel = 1;
+    handleKeydown(keyEvent('+'));
+    handleKeydown(keyEvent('+'));
+    handleKeydown(keyEvent('+'));
+    handleKeydown(keyEvent('+'));
+    expect(appState.zoomLevel).toBe(16);
+  });
+
+  it('stepping back through all levels with - reaches minimum', () => {
+    appState.zoomLevel = 16;
+    handleKeydown(keyEvent('-'));
+    handleKeydown(keyEvent('-'));
+    handleKeydown(keyEvent('-'));
+    handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBe(1);
+  });
+});
+
 describe('handleKeydown — export', () => {
   it('Ctrl+e calls exportCsv', async () => {
     const handler = vi.fn(() => undefined);

--- a/src/tests/unit/actions.seeking.test.ts
+++ b/src/tests/unit/actions.seeking.test.ts
@@ -181,3 +181,63 @@ describe('stepFwd', () => {
     expect(appState.positionMs).toBe(60_000);
   });
 });
+
+// Helper that builds a minimal HTMLDivElement stand-in for the waveform scroll container.
+// scrollWidth / clientWidth are read-only on real elements, so we use a plain object cast.
+function makeWrapEl(scrollWidth: number, clientWidth: number): HTMLDivElement {
+  return { scrollLeft: 0, scrollWidth, clientWidth } as unknown as HTMLDivElement;
+}
+
+describe('seekTo — waveform scroll sync', () => {
+  it('does not touch scrollLeft when zoomLevel is 1', async () => {
+    mockIPC(() => undefined);
+    const wrap = makeWrapEl(1000, 200);
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 1;
+    appState.durationMs = 10_000;
+    await seekTo(5000);
+    expect(wrap.scrollLeft).toBe(0);
+  });
+
+  it('scrolls to center the playhead when zoomed', async () => {
+    mockIPC(() => undefined);
+    // 2x zoom: total scrollWidth = 1000, clientWidth = 200
+    // Seeking to 50% of a 10s file → target = 0.5 * 1000 - 200/2 = 400
+    const wrap = makeWrapEl(1000, 200);
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    await seekTo(5000);
+    expect(wrap.scrollLeft).toBe(400);
+  });
+
+  it('clamps scrollLeft to 0 when computed target is negative', async () => {
+    mockIPC(() => undefined);
+    // Seeking near the start: target = 0.01 * 1000 - 100 = -90 → clamp to 0
+    const wrap = makeWrapEl(1000, 200);
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    await seekTo(100);
+    expect(wrap.scrollLeft).toBe(0);
+  });
+
+  it('does not scroll when waveformWrapEl is null', async () => {
+    mockIPC(() => undefined);
+    appState.waveformWrapEl = null;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    // Should not throw
+    await expect(seekTo(5000)).resolves.toBeUndefined();
+  });
+
+  it('does not scroll when durationMs is 0', async () => {
+    mockIPC(() => undefined);
+    const wrap = makeWrapEl(1000, 200);
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 0;
+    await seekTo(0);
+    expect(wrap.scrollLeft).toBe(0);
+  });
+});

--- a/src/tests/unit/utils.test.ts
+++ b/src/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMs, kindLabel, SPEEDS, parseTimeMs } from '$lib/utils';
+import { formatMs, kindLabel, SPEEDS, ZOOM_LEVELS, parseTimeMs } from '$lib/utils';
 
 describe('formatMs', () => {
   it('formats zero as 00:00:00.000', () => {
@@ -126,6 +126,33 @@ describe('parseTimeMs', () => {
 
   it('returns null for partially numeric input', () => {
     expect(parseTimeMs('1:ab')).toBeNull();
+  });
+});
+
+describe('ZOOM_LEVELS', () => {
+  it('starts at 1 (no zoom)', () => {
+    expect(ZOOM_LEVELS[0]).toBe(1);
+  });
+
+  it('ends at 16 (maximum zoom)', () => {
+    expect(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]).toBe(16);
+  });
+
+  it('has at least 3 steps', () => {
+    expect(ZOOM_LEVELS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('is sorted in strictly ascending order', () => {
+    for (let i = 1; i < ZOOM_LEVELS.length; i++) {
+      expect(ZOOM_LEVELS[i]).toBeGreaterThan(ZOOM_LEVELS[i - 1]);
+    }
+  });
+
+  it('contains only positive integers', () => {
+    for (const level of ZOOM_LEVELS) {
+      expect(level).toBeGreaterThan(0);
+      expect(Number.isInteger(level)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
- Adds zoom controls (1x–16x) above the waveform via +/- buttons and keyboard shortcuts
- Auto-scrolls to keep the playhead centered during playback when zoomed
- Syncs arrow key / D / F seeking with the zoomed scroll position
- Adds ZOOM_LEVELS to shared utils; tests cover zoom state, scroll sync, and keyboard shortcuts