### PR TITLE
Fix resizing issue + additional UI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Audio Ninja
-
+g
 ## Tauri + SvelteKit + TypeScript
 
 This template should help get you started developing with Tauri, SvelteKit and TypeScript in Vite.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,9 @@
       {
         "title": "Audio Ninja",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "minWidth": 700,
+        "minHeight": 500
       }
     ],
     "security": {

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -10,6 +10,11 @@
   let exportDropdownOpen = $state(false);
   let exportCsv = $state(true);
   let exportAudio = $state(true);
+  const fileFormat = $derived((() => {
+    const fileName = appState.metadata?.fileName ?? '';
+    const dot = fileName.lastIndexOf('.');
+    return dot >= 0 && dot < fileName.length - 1 ? fileName.slice(dot + 1).toUpperCase() : 'MEDIA';
+  })());
 
   function toggleDropdown() {
     exportDropdownOpen = !exportDropdownOpen;
@@ -23,7 +28,10 @@
 <header class="header">
   <div class="header-left">
     <h1 class="app-title">Media Segment Marker</h1>
-    <p class="app-sub">Precision audio/video segmentation tool</p>
+    <p class="app-sub">
+      <span class="file-name" title={appState.metadata?.fileName}>{appState.metadata?.fileName}</span>
+      <span class="file-format">{fileFormat}</span>
+    </p>
   </div>
   <div class="header-right">
     <button class="btn-export" onclick={onOpenFile}>
@@ -80,14 +88,19 @@
 </header>
 
 <style>
-  .header {
-    display: flex;
-    align-items: center;
+	  .header {
+	    display: flex;
+	    align-items: center;
     justify-content: space-between;
     padding: 10px 16px;
     border-bottom: 1px solid #21262d;
-    flex-shrink: 0;
-  }
+	    flex-shrink: 0;
+	  }
+
+	  .header-left {
+	    min-width: 0;
+	    flex: 1;
+	  }
 
   .app-title {
     font-size: 16px;
@@ -95,11 +108,33 @@
     color: #e2e8f0;
   }
 
-  .app-sub {
-    font-size: 11px;
-    color: #8b949e;
-    margin-top: 1px;
-  }
+	  .app-sub {
+	    display: flex;
+	    align-items: center;
+	    gap: 8px;
+	    min-width: 0;
+	    font-size: 11px;
+	    color: #8b949e;
+	    margin-top: 1px;
+	  }
+
+	  .file-name {
+	    min-width: 0;
+	    overflow: hidden;
+	    text-overflow: ellipsis;
+	    white-space: nowrap;
+	  }
+
+	  .file-format {
+	    flex-shrink: 0;
+	    padding: 1px 5px;
+	    background: #1e2a3a;
+	    border: 1px solid #30363d;
+	    border-radius: 5px;
+	    color: #c9d1d9;
+	    font-size: 10px;
+	    font-weight: 600;
+	  }
 
   .header-right {
     display: flex;

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -27,7 +27,7 @@
 
 <header class="header">
   <div class="header-left">
-    <h1 class="app-title">Media Segment Marker</h1>
+    <h1 class="app-title">Audio Ninja</h1>
     <p class="app-sub">
       <span class="file-name" title={appState.metadata?.fileName}>{appState.metadata?.fileName}</span>
       <span class="file-format">{fileFormat}</span>

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { appState } from '$lib/state.svelte';
   import { formatMs, parseTimeMs } from '$lib/utils';
   import { enterEditMode, cancelEditMode, confirmEditMode } from '$lib/actions';
+  import { validationProblemMarkerIds } from '$lib/validation';
   import type { MarkerKind } from '$lib/types';
 
   let { onAddMarkerNoKind, onDeleteMarker, onAddMarkerAt }: {
@@ -14,6 +16,19 @@
   let editInputValue = $state('');
   // True while the user has the edit input focused; suppresses the $effect reset
   let isTyping = false;
+  let compactMarkerTypes = $state(false);
+  let markerListEl = $state<HTMLDivElement | null>(null);
+  const validationProblemIds = $derived(validationProblemMarkerIds(appState.markers, appState.validationError));
+
+  onMount(() => {
+    const media = window.matchMedia('(max-width: 650px)');
+    const updateCompactTypes = () => {
+      compactMarkerTypes = media.matches;
+    };
+    updateCompactTypes();
+    media.addEventListener('change', updateCompactTypes);
+    return () => media.removeEventListener('change', updateCompactTypes);
+  });
 
   // Sync the input display when the draft position changes externally (nudge or mode entry)
   // but not while the user is actively typing in the field.
@@ -21,6 +36,16 @@
     if (appState.editingMarkerId !== null && !isTyping) {
       editInputValue = formatMs(appState.editingPositionMs);
     }
+  });
+
+  $effect(() => {
+    const selectedId = appState.selectedMarkerId;
+    if (!selectedId || !markerListEl) return;
+
+    queueMicrotask(() => {
+      const row = markerListEl?.querySelector<HTMLElement>(`[data-marker-id="${CSS.escape(selectedId)}"]`);
+      row?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    });
   });
 
 </script>
@@ -36,12 +61,14 @@
       No markers yet. Use the Add Marker button or press <kbd>S</kbd>, <kbd>E</kbd>, or <kbd>B</kbd>.
     </p>
   {:else}
-    <div class="marker-list">
+    <div class="marker-list" bind:this={markerListEl}>
       {#each [...appState.markers].sort((a, b) => b.position - a.position) as m (m.id)}
         <div
           class="marker-row"
           class:marker-row-selected={appState.selectedMarkerId === m.id}
           class:marker-row-editing={appState.editingMarkerId === m.id}
+          class:marker-row-validation-error={validationProblemIds.has(m.id)}
+          data-marker-id={m.id}
           onclick={() => { appState.selectedMarkerId = m.id; }}
           role="button"
           tabindex="0"
@@ -114,11 +141,11 @@
             }}
           >
             {#if appState.unkindedMarkers.has(m.id)}
-              <option value="" disabled selected>Select type…</option>
+              <option value="" disabled selected>{compactMarkerTypes ? 'Type…' : 'Select type…'}</option>
             {/if}
-            <option value="start">Start</option>
-            <option value="end">End</option>
-            <option value="startEnd">Start+End</option>
+            <option value="start">{compactMarkerTypes ? 'S' : 'Start'}</option>
+            <option value="end">{compactMarkerTypes ? 'E' : 'End'}</option>
+            <option value="startEnd">{compactMarkerTypes ? 'S+E' : 'Start+End'}</option>
           </select>
           <button
             class="edit-btn"
@@ -213,15 +240,20 @@
 
   .marker-list {
     flex: 1;
-    overflow-y: auto;
+    overflow: auto;
     padding: 4px 0;
+    min-width: 0;
   }
 
   .marker-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px 26px;
     align-items: center;
-    gap: 8px;
+    column-gap: 8px;
     padding: 7px 14px;
+    width: 100%;
+    min-width: max-content;
+    min-height: 41px;
     cursor: pointer;
     border-bottom: 1px solid #161b22;
     transition: background 0.1s;
@@ -243,13 +275,18 @@
   .dot-both   { background: #facc15; }
 
   .marker-time {
-    flex: 1;
     font-variant-numeric: tabular-nums;
     font-size: 12px;
     color: #c9d1d9;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .kind-select {
+    width: 100%;
+    min-width: 0;
     padding: 3px 6px;
     background: #1e2a3a;
     border: 1px solid #30363d;
@@ -286,8 +323,13 @@
 
   .marker-row-editing { background: #1e1a0e !important; border-left: 2px solid #f97316; }
 
+  .marker-row-validation-error {
+    background: rgba(127, 29, 29, 0.22) !important;
+    border-left: 2px solid #f87171;
+  }
+
   .edit-time-input {
-    flex: 1;
+    width: 100%;
     padding: 3px 6px;
     background: #1e2a3a;
     border: 1px solid #f97316;
@@ -316,4 +358,16 @@
 
   .edit-btn:hover { color: #f97316; border-color: #f97316; background: #1e1a0e; }
   .edit-btn-active { color: #f97316; border-color: #f97316; background: #1e1a0e; }
+
+  @media (max-width: 650px) {
+    .marker-row {
+      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px 26px;
+      column-gap: 6px;
+    }
+
+    .kind-select {
+      padding-left: 4px;
+      padding-right: 4px;
+    }
+  }
 </style>

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -123,7 +123,8 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 0;
   }
 
   .controls-label {
@@ -191,6 +192,7 @@
   .toggle-active:hover { background: #1e3f7a; color: #93c5fd; }
 
   .time-display {
+    margin-left: auto;
     font-size: 13px;
     font-variant-numeric: tabular-nums;
     color: #3b82f6;

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -95,6 +95,7 @@
   .shortcuts-collapsed .panel-header {
     justify-content: center;
     padding: 10px 6px 8px;
+    gap: 8px;
   }
 
   .panel-title {
@@ -112,6 +113,7 @@
     justify-content: center;
     width: 24px;
     height: 24px;
+    flex: 0 0 24px;
     background: #1e2a3a;
     border: 1px solid #30363d;
     border-radius: 6px;

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -86,6 +86,8 @@
     flex-direction: column;
     gap: 6px;
     flex: 1;
+    min-height: 0;
+    overflow-y: auto;
   }
 
   .shortcut-row {

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -1,53 +1,70 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
+
+  let { collapsed = false, onToggleCollapsed }: {
+    collapsed?: boolean;
+    onToggleCollapsed?: () => void;
+  } = $props();
 </script>
 
-<div class="panel shortcuts-panel">
+<div class="panel shortcuts-panel" class:shortcuts-collapsed={collapsed}>
   <div class="panel-header">
     <h3 class="panel-title">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
         <rect x="2" y="4" width="20" height="16" rx="2"/>
         <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M18 12h.01M10 12h4M6 16h12"/>
       </svg>
-      Keyboard Shortcuts
+      {#if !collapsed}
+        Keyboard Shortcuts
+      {/if}
     </h3>
+    <button
+      class="collapse-btn"
+      onclick={onToggleCollapsed}
+      title={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
+      aria-label={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
+    >
+      {collapsed ? '‹' : '›'}
+    </button>
   </div>
-  <div class="shortcut-list">
-    <div class="shortcut-subheading">Control Playback</div>
-    <div class="shortcut-row"><kbd>Space</kbd><span>Play/Pause</span></div>
-    <div class="shortcut-row">
-      <kbd>←/→</kbd>
-      <span class="seek-step-label">
-        Seek ±
-        <input class="step-input" type="number" min="100" max="60000" bind:value={appState.stepMs} />
-        ms
-      </span>
+  {#if !collapsed}
+    <div class="shortcut-list">
+      <div class="shortcut-subheading">Control Playback</div>
+      <div class="shortcut-row"><kbd>Space</kbd><span>Play/Pause</span></div>
+      <div class="shortcut-row">
+        <kbd>←/→</kbd>
+        <span class="seek-step-label">
+          Seek ±
+          <input class="step-input" type="number" min="100" max="60000" bind:value={appState.stepMs} />
+          ms
+        </span>
+      </div>
+      <div class="shortcut-row"><kbd>1–5</kbd><span>Playback Speed</span></div>
+
+      <div class="shortcut-subheading">Waveform Zoom</div>
+      <div class="shortcut-row"><kbd>-</kbd><span>Zoom out</span></div>
+      <div class="shortcut-row"><kbd>+</kbd><span>Zoom in</span></div>
+
+      <div class="shortcut-subheading">Add Marker</div>
+      <div class="shortcut-row"><kbd>S</kbd><span>Start</span></div>
+      <div class="shortcut-row"><kbd>E</kbd><span>End</span></div>
+      <div class="shortcut-row"><kbd>B</kbd><span>Start+End</span></div>
+
+      <div class="shortcut-subheading">Manage Markers</div>
+      <div class="shortcut-row"><kbd>D</kbd><span>Previous Marker</span></div>
+      <div class="shortcut-row"><kbd>F</kbd><span>Next Marker</span></div>
+      <div class="shortcut-row"><kbd>Del</kbd><span>Delete Selected Marker</span></div>
+
+      <div class="shortcut-subheading">Edit Marker</div>
+      <div class="shortcut-row"><kbd>[</kbd><span>Nudge left 100ms</span></div>
+      <div class="shortcut-row"><kbd>]</kbd><span>Nudge right 100ms</span></div>
+      <div class="shortcut-row"><kbd>Enter</kbd><span>Confirm position</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Cancel editing</span></div>
+
+      <div class="shortcut-subheading">Export</div>
+      <div class="shortcut-row"><kbd>Ctrl+E</kbd><span>Export CSV</span></div>
     </div>
-    <div class="shortcut-row"><kbd>1–5</kbd><span>Playback Speed</span></div>
-
-    <div class="shortcut-subheading">Waveform Zoom</div>
-    <div class="shortcut-row"><kbd>-</kbd><span>Zoom out</span></div>
-    <div class="shortcut-row"><kbd>+</kbd><span>Zoom in</span></div>
-
-    <div class="shortcut-subheading">Add Marker</div>
-    <div class="shortcut-row"><kbd>S</kbd><span>Start</span></div>
-    <div class="shortcut-row"><kbd>E</kbd><span>End</span></div>
-    <div class="shortcut-row"><kbd>B</kbd><span>Start+End</span></div>
-
-    <div class="shortcut-subheading">Manage Markers</div>
-    <div class="shortcut-row"><kbd>D</kbd><span>Previous Marker</span></div>
-    <div class="shortcut-row"><kbd>F</kbd><span>Next Marker</span></div>
-    <div class="shortcut-row"><kbd>Del</kbd><span>Delete Selected Marker</span></div>
-
-    <div class="shortcut-subheading">Edit Marker</div>
-    <div class="shortcut-row"><kbd>[</kbd><span>Nudge left 100ms</span></div>
-    <div class="shortcut-row"><kbd>]</kbd><span>Nudge right 100ms</span></div>
-    <div class="shortcut-row"><kbd>Enter</kbd><span>Confirm position</span></div>
-    <div class="shortcut-row"><kbd>Esc</kbd><span>Cancel editing</span></div>
-
-    <div class="shortcut-subheading">Export</div>
-    <div class="shortcut-row"><kbd>Ctrl+E</kbd><span>Export CSV</span></div>
-  </div>
+  {/if}
 </div>
 
 <style>
@@ -62,6 +79,10 @@
     background: #0f1419;
   }
 
+  .shortcuts-collapsed {
+    align-items: stretch;
+  }
+
   .panel-header {
     display: flex;
     align-items: center;
@@ -71,6 +92,11 @@
     flex-shrink: 0;
   }
 
+  .shortcuts-collapsed .panel-header {
+    justify-content: center;
+    padding: 10px 6px 8px;
+  }
+
   .panel-title {
     display: flex;
     align-items: center;
@@ -78,6 +104,26 @@
     font-size: 13px;
     font-weight: 600;
     color: #c9d1d9;
+  }
+
+  .collapse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    background: #1e2a3a;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #8b949e;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  .collapse-btn:hover {
+    color: #e2e8f0;
+    border-color: #4d6a8a;
   }
 
   .shortcut-list {

--- a/src/components/SuccessToast.svelte
+++ b/src/components/SuccessToast.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { appState } from '$lib/state.svelte';
+
+  $effect(() => {
+    if (!appState.successMessage) return;
+
+    const timeout = window.setTimeout(() => {
+      appState.successMessage = null;
+    }, 3200);
+
+    return () => window.clearTimeout(timeout);
+  });
+
+  function dismiss() {
+    appState.successMessage = null;
+  }
+</script>
+
+{#if appState.successMessage}
+  <div class="success-toast" role="status" aria-live="polite">
+    <span class="toast-dot"></span>
+    <span class="toast-message">{appState.successMessage}</span>
+    <button class="toast-dismiss" onclick={dismiss} aria-label="Dismiss success message">x</button>
+  </div>
+{/if}
+
+<style>
+  .success-toast {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: min(360px, calc(100vw - 32px));
+    padding: 10px 12px;
+    background: #10251a;
+    border: 1px solid #1f7a45;
+    border-radius: 8px;
+    color: #d8f3df;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  .toast-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #22c55e;
+    flex-shrink: 0;
+  }
+
+  .toast-message {
+    min-width: 0;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .toast-dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-left: 4px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: #9dd8ad;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  .toast-dismiss:hover {
+    border-color: #1f7a45;
+    background: #153321;
+    color: #d8f3df;
+  }
+</style>

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -3,9 +3,11 @@
   import WaveSurfer from 'wavesurfer.js';
   import { appState } from '$lib/state.svelte';
   import { kindLabel, formatMs, ZOOM_LEVELS } from '$lib/utils';
+  import { validationProblemMarkerIds } from '$lib/validation';
 
   let waveformEl     = $state<HTMLDivElement | null>(null);
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
+  const validationProblemIds = $derived(validationProblemMarkerIds(appState.markers, appState.validationError));
 
   // Expose the wrap element so external code can scroll it if needed
   $effect(() => { appState.waveformWrapEl = waveformWrapEl; });
@@ -169,12 +171,14 @@
         <!-- Ghost at original position -->
         <div
           class="marker-line marker-ghost"
+          class:marker-validation-error={validationProblemIds.has(m.id)}
           style="left: {origPct}%"
           title="Original — {formatMs(m.position)}"
         ></div>
         <!-- Draft at new position -->
         <div
           class="marker-line marker-editing"
+          class:marker-validation-error={validationProblemIds.has(m.id)}
           style="left: {draftPct}%"
           title="{kindLabel(m.kind)} — {formatMs(appState.editingPositionMs)}"
         ></div>
@@ -182,6 +186,7 @@
         <div
           class="marker-line"
           class:marker-selected={appState.selectedMarkerId === m.id}
+          class:marker-validation-error={validationProblemIds.has(m.id)}
           style="left: {origPct}%"
           title="{kindLabel(m.kind)} — {formatMs(m.position)}"
         ></div>
@@ -279,6 +284,13 @@
     opacity: 1;
     box-shadow: 0 0 8px #f97316;
     animation: editing-pulse 1s ease-in-out infinite alternate;
+  }
+
+  .marker-line.marker-validation-error {
+    background: #f87171;
+    opacity: 1;
+    width: 3px;
+    box-shadow: 0 0 8px rgba(248, 113, 113, 0.85);
   }
 
   @keyframes editing-pulse {

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -26,7 +26,7 @@
       progressColor: '#3b82f6',
       cursorColor: '#ffffff',
       cursorWidth: 2,
-      height: 180,
+      height: waveformWrapEl?.clientHeight || 180,
       barWidth: 2,
       barGap: 1,
       barRadius: 2,
@@ -36,7 +36,14 @@
     ws.load(convertFileSrc(filePath));
     appState.wavesurfer = ws;
 
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      const height = Math.round(entry.contentRect.height);
+      if (height > 0) ws.setOptions({ height });
+    });
+    if (waveformWrapEl) resizeObserver.observe(waveformWrapEl);
+
     return () => {
+      resizeObserver.disconnect();
       ws.destroy();
       appState.wavesurfer = null;
     };
@@ -223,7 +230,7 @@
   .waveform-wrap {
     position: relative;
     width: 100%;
-    height: 180px;
+    height: clamp(120px, 24vh, 180px);
     flex-shrink: 0;
     background: #0d1117;
     border-bottom: 1px solid #21262d;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -184,6 +184,7 @@ export async function stepFwd() {
 export async function openFile() {
   try {
     appState.error = null;
+    appState.successMessage = null;
     const meta = await invoke<FileMetadata>('open_file_dialog');
     appState.metadata        = meta;
     appState.durationMs      = meta.durationMs;
@@ -204,6 +205,7 @@ export async function openFile() {
 export async function togglePlay() {
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke(appState.isPlaying ? 'pause' : 'play');
   } catch (e) {
     appState.error = String(e);
@@ -214,6 +216,7 @@ export async function setSpeed(s: number) {
   appState.speed = s;
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('set_speed', { speed: s });
   } catch (e) {
     appState.error = String(e);
@@ -228,6 +231,7 @@ export async function handleLoop(enabled: boolean) {
   appState.looping = enabled;
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('set_loop', { enabled });
   } catch (e) {
     appState.error = String(e);
@@ -241,6 +245,7 @@ export async function addMarker(kind: MarkerKind) {
 export async function addMarkerNoKind() {
   try {
     appState.error = null;
+    appState.successMessage = null;
     const m = await invoke<Marker>('add_marker', {
       positionMs: Math.round(appState.positionMs),
       kind: 'start',
@@ -258,6 +263,7 @@ export async function addMarkerNoKind() {
 export async function addMarkerAt(kind: MarkerKind, posMs: number) {
   try {
     appState.error = null;
+    appState.successMessage = null;
     const m = await invoke<Marker>('add_marker', {
       positionMs: Math.round(posMs),
       kind,
@@ -276,6 +282,7 @@ export async function addMarkerAt(kind: MarkerKind, posMs: number) {
 export async function deleteMarker(id: string) {
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('delete_marker', { id });
     appState.markers = appState.markers.filter(m => m.id !== id);
     const updated = { ...appState.renameInputs };
@@ -317,6 +324,7 @@ export async function confirmEditMode() {
   appState.editingPositionMs = 0;
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('move_marker', { id, newPositionMs: positionMs });
     appState.markers = appState.markers
       .map(m => m.id === id ? { ...m, position: positionMs } : m)
@@ -372,6 +380,7 @@ export function computePreviewSegments(): Segment[] {
 export async function renameSegment(anchorId: string) {
   try {
     appState.error = null;
+    appState.successMessage = null;
     const title = appState.renameInputs[anchorId] ?? '';
     await invoke('rename_segment', { anchorId, title });
     await revalidate();
@@ -421,7 +430,9 @@ export async function revalidate() {
 export async function exportCsv() {
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('export_csv');
+    appState.successMessage = 'CSV exported successfully.';
   } catch (e) {
     appState.error = String(e);
   }
@@ -430,7 +441,11 @@ export async function exportCsv() {
 export async function exportAudioSegments(exportCsv: boolean, exportAudio: boolean) {
   try {
     appState.error = null;
+    appState.successMessage = null;
     await invoke('export_audio_segments', {exportCsv, exportAudio});
+    if (exportCsv && exportAudio) appState.successMessage = 'CSV and audio segments exported successfully.';
+    else if (exportCsv) appState.successMessage = 'CSV exported successfully.';
+    else if (exportAudio) appState.successMessage = 'Audio segments exported successfully.';
   } catch (e) {
     appState.error = String(e);
   }
@@ -439,6 +454,7 @@ export async function exportAudioSegments(exportCsv: boolean, exportAudio: boole
 export async function importCsv() {
   try {
     appState.error = null;
+    appState.successMessage = null;
     const markers = await invoke<Marker[]>('import_csv');
     appState.markers = markers.sort((a, b) => a.position - b.position);
     appState.renameInputs = Object.fromEntries(

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -10,6 +10,7 @@ class AppState {
   markers         = $state<Marker[]>([]);
   segments        = $state<Segment[] | null>(null);
   error           = $state<string | null>(null);
+  successMessage  = $state<string | null>(null);
   stepMs          = $state(5000);
   speed           = $state(1.0);
   looping         = $state(false);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,43 @@
+import type { Marker } from './types';
+
+export function validationProblemMarkerIds(markers: Marker[], error: string | null): Set<string> {
+  if (!error) return new Set();
+
+  const sorted = [...markers].sort((a, b) => a.position - b.position);
+  const message = error.toLowerCase();
+
+  if (message.includes('no preceding start')) {
+    let waitingForEnd = false;
+    for (const marker of sorted) {
+      if (marker.kind === 'start') waitingForEnd = true;
+      else if (marker.kind === 'end') {
+        if (!waitingForEnd) return new Set([marker.id]);
+        waitingForEnd = false;
+      }
+    }
+  }
+
+  if (message.includes('two consecutive start')) {
+    let pendingStart: Marker | null = null;
+    for (const marker of sorted) {
+      if (marker.kind === 'start') {
+        if (pendingStart) return new Set([pendingStart.id, marker.id]);
+        pendingStart = marker;
+      } else if (marker.kind === 'end') {
+        pendingStart = null;
+      } else if (marker.kind === 'startEnd') {
+        pendingStart = pendingStart ? marker : null;
+      }
+    }
+  }
+
+  if (message.includes('unmatched start')) {
+    const position = error.match(/position\s+(\d+)\s+ms/i)?.[1];
+    const unmatched = position
+      ? sorted.find(marker => (marker.kind === 'start' || marker.kind === 'startEnd') && marker.position === Number(position))
+      : [...sorted].reverse().find(marker => marker.kind === 'start' || marker.kind === 'startEnd');
+    if (unmatched) return new Set([unmatched.id]);
+  }
+
+  return new Set();
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -111,7 +111,7 @@
 	  }
 
 	  .panels.shortcuts-collapsed {
-	    grid-template-columns: minmax(180px, 1fr) minmax(260px, 2fr) 42px;
+	    grid-template-columns: minmax(180px, 1fr) minmax(260px, 2fr) 58px;
 	  }
 
 	  @media (max-width: 900px) {
@@ -120,7 +120,7 @@
 	    }
 
 	    .panels.shortcuts-collapsed {
-	      grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr) 40px;
+	      grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr) 58px;
 	    }
 	  }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,13 +17,26 @@
   import SegmentPanel from '../components/SegmentPanel.svelte';
   import ShortcutsPanel from '../components/ShortcutsPanel.svelte';
   import ErrorAlert from '../components/ErrorAlert.svelte';
+  import SuccessToast from '../components/SuccessToast.svelte';
+
+  let shortcutsCollapsed = $state(false);
 
   onMount(() => {
     document.addEventListener('keydown', handleKeydown);
+    const media = window.matchMedia('(max-width: 900px)');
+    const syncShortcutsLayout = () => {
+      shortcutsCollapsed = media.matches;
+    };
+    syncShortcutsLayout();
+    media.addEventListener('change', syncShortcutsLayout);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeydown);
+      media.removeEventListener('change', syncShortcutsLayout);
+    };
   });
 
   onDestroy(() => {
-    document.removeEventListener('keydown', handleKeydown);
     stopPolling();
     stopRaf();
     if (appState.wavesurfer) appState.wavesurfer.destroy();
@@ -31,6 +44,7 @@
 </script>
 
 <ErrorAlert />
+<SuccessToast />
 
 {#if !appState.metadata}
   <WelcomeScreen onOpenFile={openFile} />
@@ -49,15 +63,18 @@
       onToggleLoop={handleLoop}
       onToggleFollow={handleFollowPlayhead}
     />
-    <div class="panels">
-      <MarkerPanel
-        onAddMarkerNoKind={addMarkerNoKind}
-        onDeleteMarker={deleteMarker}
-        onAddMarkerAt={addMarkerAt}
-      />
-      <SegmentPanel onRenameSegment={renameSegment} />
-      <ShortcutsPanel />
-    </div>
+	    <div class="panels" class:shortcuts-collapsed={shortcutsCollapsed}>
+	      <MarkerPanel
+	        onAddMarkerNoKind={addMarkerNoKind}
+	        onDeleteMarker={deleteMarker}
+	        onAddMarkerAt={addMarkerAt}
+	      />
+	      <SegmentPanel onRenameSegment={renameSegment} />
+	      <ShortcutsPanel
+	        collapsed={shortcutsCollapsed}
+	        onToggleCollapsed={() => { shortcutsCollapsed = !shortcutsCollapsed; }}
+	      />
+	    </div>
   </div>
 {/if}
 
@@ -85,13 +102,27 @@
     overflow: hidden;
   }
 
-  .panels {
-    display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
-    flex: 1;
-    overflow: hidden;
-    min-height: 0;
-  }
+	  .panels {
+	    display: grid;
+	    grid-template-columns: minmax(180px, 1fr) minmax(260px, 2fr) minmax(180px, 1fr);
+	    flex: 1;
+	    overflow: hidden;
+	    min-height: 0;
+	  }
+
+	  .panels.shortcuts-collapsed {
+	    grid-template-columns: minmax(180px, 1fr) minmax(260px, 2fr) 42px;
+	  }
+
+	  @media (max-width: 900px) {
+	    .panels {
+	      grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr) minmax(170px, 0.9fr);
+	    }
+
+	    .panels.shortcuts-collapsed {
+	      grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr) 40px;
+	    }
+	  }
 
   :global(::-webkit-scrollbar) { width: 6px; }
   :global(::-webkit-scrollbar-track) { background: transparent; }

--- a/src/tests/helpers/reset-state.ts
+++ b/src/tests/helpers/reset-state.ts
@@ -8,6 +8,7 @@ export function resetAppState() {
   appState.markers          = [];
   appState.segments         = null;
   appState.error            = null;
+  appState.successMessage   = null;
   appState.stepMs           = 5000;
   appState.speed            = 1.0;
   appState.looping          = false;

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+import { beforeEach, afterEach } from 'vitest';
 
 // Polyfill requestAnimationFrame for jsdom
 if (!globalThis.requestAnimationFrame) {

--- a/src/tests/unit/actions.playback.test.ts
+++ b/src/tests/unit/actions.playback.test.ts
@@ -163,13 +163,13 @@ describe('exportAudioSegments', () => {
   it('calls export_audio_segments command', async () => {
     const handler = vi.fn(() => undefined);
     mockIPC(handler);
-    await exportAudioSegments();
-    expect(handler).toHaveBeenCalledWith('export_audio_segments', expect.anything());
+    await exportAudioSegments(true, true);
+    expect(handler).toHaveBeenCalledWith('export_audio_segments', { exportCsv: true, exportAudio: true });
   });
 
   it('sets appState.error when invoke throws', async () => {
     mockIPC(() => { throw new Error('export failed'); });
-    await exportAudioSegments();
+    await exportAudioSegments(true, true);
     expect(appState.error).toMatch('export failed');
   });
 });

--- a/src/tests/unit/actions.polling.test.ts
+++ b/src/tests/unit/actions.polling.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 
 describe('startPolling', () => {
   it('calls get_playback_position after 100ms', async () => {
-    const handler = vi.fn(() => playbackPos(1000));
+    const handler = vi.fn((cmd: string) => cmd === 'get_playback_position' ? playbackPos(1000) : undefined);
     mockIPC(handler);
 
     startPolling();
@@ -98,7 +98,7 @@ describe('stopPolling', () => {
   });
 
   it('stops further polling calls', async () => {
-    const handler = vi.fn(() => playbackPos(0));
+    const handler = vi.fn((cmd: string) => cmd === 'get_playback_position' ? playbackPos(0) : undefined);
     mockIPC(handler);
     startPolling();
     stopPolling();


### PR DESCRIPTION
This PR attempts to improve the layout and sizing issues of the various panels/components in the UI for various window sizes. Enforcing a minimum window size of 500x700 improved it significantly. Other fixes include:

- Made the waveform height responsive with a 120px to 180px clamp.
- Added internal scrolling for shortcuts panel 
- Converted marker rows from flex layout to grid layout so timestamp, marker type, edit, and delete controls are cleaner
- Added responsive/collapsible shortcuts behavior: markers remain visible, segments stay central, and shortcuts collapse into a narrow rail on smaller widths.

Other features added: 

- File name/type added to header
- Popup when export is successful 
- Markers that fail validation gently highlighted in red in waveform and markers panel 

