### PR TITLE
Add splitting logic for start end markers

### DIFF
--- a/src-tauri/src/markers/validate.rs
+++ b/src-tauri/src/markers/validate.rs
@@ -3,86 +3,83 @@ use super::model::{Marker, MarkerKind, Segment};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-/// Pair sorted markers into validated segments.
+/// Pair sorted markers into validated segments using a stack (valid-parentheses model).
 ///
 /// Rules:
-/// - Every `Start` must be followed immediately by an `End`
-/// - `End` cannot appear without a preceding `Start`
-/// - `StartEnd` emits a zero-span segment on its own
-/// - Two consecutive `Start` markers (or a `StartEnd` while waiting) → error
-/// - An unmatched `Start` at end-of-list → error
+/// - `Start` pushes onto the open-segment stack.
+/// - `End` pops the most-recently-opened start and closes a segment.
+///   An `End` with nothing on the stack is an error.
+/// - `StartEnd` closes the most-recently-opened start (if any) and pushes
+///   itself as a new open start.  A standalone `StartEnd` (empty stack) emits
+///   a zero-span segment without opening a new pending start.
+/// - Any starts remaining on the stack after all markers are processed are errors.
+///
+/// Segments may overlap when multiple starts are open simultaneously.
 pub fn to_segments(
     markers: &[Marker],
     titles: &HashMap<Uuid, String>,
 ) -> Result<Vec<Segment>> {
-    #[derive(Debug)]
-    enum State<'a> {
-        Idle,
-        WaitingForEnd(&'a Marker),
-    }
-
-    let mut state = State::Idle;
+    let mut stack: Vec<&Marker> = Vec::new();
     let mut segments: Vec<Segment> = Vec::new();
 
     for m in markers {
-        match (&state, m.kind) {
-            (State::Idle, MarkerKind::Start) => {
-                state = State::WaitingForEnd(m);
+        match m.kind {
+            MarkerKind::Start => {
+                stack.push(m);
             }
-            (State::Idle, MarkerKind::StartEnd) => {
-                let title = titles
-                    .get(&m.id)
-                    .cloned()
-                    .unwrap_or_else(|| format!("Segment {}", segments.len()));
-                segments.push(Segment {
-                    start_ms: m.position,
-                    end_ms: m.position,
-                    title,
-                });
+            MarkerKind::End => {
+                match stack.pop() {
+                    None => {
+                        return Err(AppError::ValidationError(
+                            "End marker found with no preceding Start marker".into(),
+                        ));
+                    }
+                    Some(start) => {
+                        let title = titles
+                            .get(&start.id)
+                            .cloned()
+                            .unwrap_or_else(|| format!("Segment {}", segments.len()));
+                        segments.push(Segment {
+                            start_ms: start.position,
+                            end_ms: m.position,
+                            title,
+                        });
+                    }
+                }
             }
-            (State::Idle, MarkerKind::End) => {
-                return Err(AppError::ValidationError(
-                    "End marker found with no preceding Start marker".into(),
-                ));
-            }
-            (State::WaitingForEnd(start), MarkerKind::End) => {
-                let title = titles
-                    .get(&start.id)
-                    .cloned()
-                    .unwrap_or_else(|| format!("Segment {}", segments.len()));
-                segments.push(Segment {
-                    start_ms: start.position,
-                    end_ms: m.position,
-                    title,
-                });
-                state = State::Idle;
-            }
-            (State::WaitingForEnd(start), MarkerKind::StartEnd) => {
-                // StartEnd closes the pending Start segment and simultaneously
-                // opens a new one, so the next End can close it.
-                let title = titles
-                    .get(&start.id)
-                    .cloned()
-                    .unwrap_or_else(|| format!("Segment {}", segments.len()));
-                segments.push(Segment {
-                    start_ms: start.position,
-                    end_ms: m.position,
-                    title,
-                });
-                state = State::WaitingForEnd(m);
-            }
-            (State::WaitingForEnd(_), MarkerKind::Start) => {
-                return Err(AppError::ValidationError(
-                    "Two consecutive Start markers found without an End marker between them".into(),
-                ));
+            MarkerKind::StartEnd => {
+                if let Some(start) = stack.pop() {
+                    // Closes the most-recent open segment and opens a new one.
+                    let title = titles
+                        .get(&start.id)
+                        .cloned()
+                        .unwrap_or_else(|| format!("Segment {}", segments.len()));
+                    segments.push(Segment {
+                        start_ms: start.position,
+                        end_ms: m.position,
+                        title,
+                    });
+                    stack.push(m);
+                } else {
+                    // Standalone StartEnd with nothing open: zero-span segment.
+                    let title = titles
+                        .get(&m.id)
+                        .cloned()
+                        .unwrap_or_else(|| format!("Segment {}", segments.len()));
+                    segments.push(Segment {
+                        start_ms: m.position,
+                        end_ms: m.position,
+                        title,
+                    });
+                }
             }
         }
     }
 
-    if let State::WaitingForEnd(start) = state {
+    if let Some(unmatched) = stack.first() {
         return Err(AppError::ValidationError(format!(
             "Unmatched Start marker at position {} ms has no corresponding End marker",
-            start.position
+            unmatched.position
         )));
     }
 
@@ -154,11 +151,34 @@ mod tests {
     }
 
     #[test]
-    fn two_consecutive_starts_is_error() {
+    fn two_starts_with_no_matching_ends_is_error() {
+        // Both starts are unmatched — the outermost (earliest) is reported.
         let s1 = marker(1000, MarkerKind::Start);
         let s2 = marker(2000, MarkerKind::Start);
         let result = to_segments(&[s1, s2], &HashMap::new());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn overlapping_segments_are_valid() {
+        // start → start → end → end produces two overlapping segments.
+        let s1 = marker(0, MarkerKind::Start);
+        let s2 = marker(1000, MarkerKind::Start);
+        let e1 = marker(4000, MarkerKind::End);
+        let e2 = marker(5000, MarkerKind::End);
+        let mut titles = HashMap::new();
+        titled(&s1, &mut titles, "Outer");
+        titled(&s2, &mut titles, "Inner");
+        let segments = to_segments(&[s1, s2, e1, e2], &titles).unwrap();
+        assert_eq!(segments.len(), 2);
+        // Inner segment: s2 closed by the first end
+        assert_eq!(segments[0].start_ms, 1000);
+        assert_eq!(segments[0].end_ms, 4000);
+        assert_eq!(segments[0].title, "Inner");
+        // Outer segment: s1 closed by the second end
+        assert_eq!(segments[1].start_ms, 0);
+        assert_eq!(segments[1].end_ms, 5000);
+        assert_eq!(segments[1].title, "Outer");
     }
 
     #[test]
@@ -169,7 +189,9 @@ mod tests {
     }
 
     #[test]
-    fn start_then_startend_is_error() {
+    fn startend_without_closing_end_is_error() {
+        // start → startEnd creates a segment then pushes startEnd as new open start.
+        // Without a following end, the startEnd is unmatched.
         let s = marker(1000, MarkerKind::Start);
         let se = marker(2000, MarkerKind::StartEnd);
         let result = to_segments(&[s, se], &HashMap::new());

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -6,10 +6,11 @@
   import { validationProblemMarkerIds } from '$lib/validation';
   import type { MarkerKind } from '$lib/types';
 
-  let { onAddMarkerNoKind, onDeleteMarker, onAddMarkerAt }: {
+  let { onAddMarkerNoKind, onDeleteMarker, onAddMarkerAt, onSplitStartEndMarker }: {
     onAddMarkerNoKind: () => Promise<void>;
     onDeleteMarker: (id: string) => Promise<void>;
     onAddMarkerAt: (kind: MarkerKind, pos: number) => Promise<void>;
+    onSplitStartEndMarker: (id: string) => Promise<void>;
   } = $props();
 
   // Local string state for the edit input — avoids fighting the user while typing
@@ -162,6 +163,23 @@
               <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
             </svg>
           </button>
+          {#if m.kind === 'startEnd'}
+            <button
+              class="split-btn"
+              onclick={(e) => { e.stopPropagation(); onSplitStartEndMarker(m.id); }}
+              title="Split into Start + End markers (X)"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                <circle cx="6" cy="6" r="3"/>
+                <circle cx="6" cy="18" r="3"/>
+                <line x1="20" y1="4" x2="8.12" y2="15.88"/>
+                <line x1="14.47" y1="14.48" x2="20" y2="20"/>
+                <line x1="8.12" y1="8.12" x2="12" y2="12"/>
+              </svg>
+            </button>
+          {:else}
+            <span class="split-placeholder"></span>
+          {/if}
           <button
             class="delete-btn"
             onclick={(e) => { e.stopPropagation(); onDeleteMarker(m.id); }}
@@ -247,7 +265,7 @@
 
   .marker-row {
     display: grid;
-    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px 26px;
+    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px 26px 26px;
     align-items: center;
     column-gap: 8px;
     padding: 7px 14px;
@@ -359,9 +377,32 @@
   .edit-btn:hover { color: #f97316; border-color: #f97316; background: #1e1a0e; }
   .edit-btn-active { color: #f97316; border-color: #f97316; background: #1e1a0e; }
 
+  .split-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: #4d5b6b;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    flex-shrink: 0;
+  }
+
+  .split-btn:hover { color: #facc15; border-color: #facc15; background: #1e1c0a; }
+
+  .split-placeholder {
+    width: 26px;
+    height: 26px;
+    flex-shrink: 0;
+  }
+
   @media (max-width: 650px) {
     .marker-row {
-      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px 26px;
+      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px 26px 26px;
       column-gap: 6px;
     }
 

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -53,6 +53,7 @@
       <div class="shortcut-subheading">Manage Markers</div>
       <div class="shortcut-row"><kbd>D</kbd><span>Previous Marker</span></div>
       <div class="shortcut-row"><kbd>F</kbd><span>Next Marker</span></div>
+      <div class="shortcut-row"><kbd>X</kbd><span>Split Start+End Marker</span></div>
       <div class="shortcut-row"><kbd>Del</kbd><span>Delete Selected Marker</span></div>
 
       <div class="shortcut-subheading">Edit Marker</div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -95,6 +95,14 @@ export function handleKeydown(e: KeyboardEvent) {
   } else if (e.key === 'b' || e.key === 'B') {
     e.preventDefault();
     addMarker('startEnd');
+  } else if (e.key === 'x' || e.key === 'X') {
+    if (appState.selectedMarkerId) {
+      const m = appState.markers.find(mk => mk.id === appState.selectedMarkerId);
+      if (m?.kind === 'startEnd') {
+        e.preventDefault();
+        splitStartEndMarker(appState.selectedMarkerId);
+      }
+    }
   } else if (e.key === 'Delete' || e.key === 'Backspace') {
     if (appState.selectedMarkerId) {
       e.preventDefault();
@@ -301,6 +309,20 @@ export async function deleteMarker(id: string) {
   }
 }
 
+export async function splitStartEndMarker(id: string) {
+  const marker = appState.markers.find(m => m.id === id);
+  if (!marker || marker.kind !== 'startEnd') return;
+  const pos = marker.position;
+  const title = appState.renameInputs[id] ?? '';
+  await deleteMarker(id);
+  await addMarkerAt('end', pos);
+  await addMarkerAt('start', pos);
+  if (title && appState.selectedMarkerId) {
+    appState.renameInputs = { ...appState.renameInputs, [appState.selectedMarkerId]: title };
+    await revalidate();
+  }
+}
+
 // ── Marker position editing ───────────────────────────────────────────────
 
 export function enterEditMode(markerId: string) {
@@ -352,25 +374,26 @@ export function computePreviewSegments(): Segment[] {
     .sort((a, b) => a.position - b.position);
 
   const result: Segment[] = [];
-  let pendingStart: Marker | null = null;
+  const stack: Marker[] = [];
 
   for (const m of previewMarkers) {
-    if (m.kind === 'startEnd') {
-      if (pendingStart) {
-        result.push({ startMs: pendingStart.position, endMs: m.position,
-          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
-        pendingStart = m;
+    if (m.kind === 'start') {
+      stack.push(m);
+    } else if (m.kind === 'end') {
+      if (stack.length > 0) {
+        const start = stack.pop()!;
+        result.push({ startMs: start.position, endMs: m.position,
+          title: appState.renameInputs[start.id] || `Segment ${result.length}` });
+      }
+    } else if (m.kind === 'startEnd') {
+      if (stack.length > 0) {
+        const start = stack.pop()!;
+        result.push({ startMs: start.position, endMs: m.position,
+          title: appState.renameInputs[start.id] || `Segment ${result.length}` });
+        stack.push(m);
       } else {
         result.push({ startMs: m.position, endMs: m.position,
           title: appState.renameInputs[m.id] || `Segment ${result.length}` });
-      }
-    } else if (m.kind === 'start') {
-      pendingStart = m;
-    } else if (m.kind === 'end') {
-      if (pendingStart) {
-        result.push({ startMs: pendingStart.position, endMs: m.position,
-          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
-        pendingStart = null;
       }
     }
   }
@@ -392,25 +415,26 @@ export async function renameSegment(anchorId: string) {
 export function computePartialSegments(): Segment[] {
   const sorted = [...appState.markers].sort((a, b) => a.position - b.position);
   const result: Segment[] = [];
-  let pendingStart: Marker | null = null;
+  const stack: Marker[] = [];
 
   for (const m of sorted) {
-    if (m.kind === 'startEnd') {
-      if (pendingStart) {
-        result.push({ startMs: pendingStart.position, endMs: m.position,
-          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
-        pendingStart = m;
+    if (m.kind === 'start') {
+      stack.push(m);
+    } else if (m.kind === 'end') {
+      if (stack.length > 0) {
+        const start = stack.pop()!;
+        result.push({ startMs: start.position, endMs: m.position,
+          title: appState.renameInputs[start.id] || `Segment ${result.length}` });
+      }
+    } else if (m.kind === 'startEnd') {
+      if (stack.length > 0) {
+        const start = stack.pop()!;
+        result.push({ startMs: start.position, endMs: m.position,
+          title: appState.renameInputs[start.id] || `Segment ${result.length}` });
+        stack.push(m);
       } else {
         result.push({ startMs: m.position, endMs: m.position,
           title: appState.renameInputs[m.id] || `Segment ${result.length}` });
-      }
-    } else if (m.kind === 'start') {
-      pendingStart = m;
-    } else if (m.kind === 'end') {
-      if (pendingStart) {
-        result.push({ startMs: pendingStart.position, endMs: m.position,
-          title: appState.renameInputs[pendingStart.id] || `Segment ${result.length}` });
-        pendingStart = null;
       }
     }
   }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -7,26 +7,18 @@ export function validationProblemMarkerIds(markers: Marker[], error: string | nu
   const message = error.toLowerCase();
 
   if (message.includes('no preceding start')) {
-    let waitingForEnd = false;
-    for (const marker of sorted) {
-      if (marker.kind === 'start') waitingForEnd = true;
-      else if (marker.kind === 'end') {
-        if (!waitingForEnd) return new Set([marker.id]);
-        waitingForEnd = false;
-      }
-    }
-  }
-
-  if (message.includes('two consecutive start')) {
-    let pendingStart: Marker | null = null;
+    // Simulate the stack to find the first end that hits an empty stack.
+    // startEnd with nothing open increments the count (opens a new pending start);
+    // startEnd with something open is net-zero (closes one, opens one).
+    let count = 0;
     for (const marker of sorted) {
       if (marker.kind === 'start') {
-        if (pendingStart) return new Set([pendingStart.id, marker.id]);
-        pendingStart = marker;
-      } else if (marker.kind === 'end') {
-        pendingStart = null;
+        count++;
       } else if (marker.kind === 'startEnd') {
-        pendingStart = pendingStart ? marker : null;
+        if (count === 0) count++;
+      } else if (marker.kind === 'end') {
+        if (count === 0) return new Set([marker.id]);
+        count--;
       }
     }
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import {
     stopPolling, stopRaf, handleKeydown,
     openFile, importCsv, togglePlay, setSpeed, handleLoop,
-    addMarkerNoKind, addMarkerAt, deleteMarker,
+    addMarkerNoKind, addMarkerAt, deleteMarker, splitStartEndMarker,
     renameSegment, exportAudioSegments,
     stepBack, stepFwd, handleFollowPlayhead
   } from '$lib/actions';
@@ -68,6 +68,7 @@
 	        onAddMarkerNoKind={addMarkerNoKind}
 	        onDeleteMarker={deleteMarker}
 	        onAddMarkerAt={addMarkerAt}
+	        onSplitStartEndMarker={splitStartEndMarker}
 	      />
 	      <SegmentPanel onRenameSegment={renameSegment} />
 	      <ShortcutsPanel

--- a/src/tests/unit/actions.editing.test.ts
+++ b/src/tests/unit/actions.editing.test.ts
@@ -335,4 +335,15 @@ describe('computePreviewSegments', () => {
     appState.editingPositionMs = 2000;
     expect(computePreviewSegments()).toEqual([]);
   });
+
+  it('closes the pending segment at an edited startEnd marker then opens a new one', () => {
+    appState.markers = [marker('s1', 0, 'start'), marker('b1', 3000, 'startEnd'), marker('e1', 6000, 'end')];
+    appState.renameInputs = { s1: 'Intro', b1: 'Chorus' };
+    appState.editingMarkerId = 'b1';
+    appState.editingPositionMs = 4000;
+    const result = computePreviewSegments();
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ startMs: 0, endMs: 4000, title: 'Intro' });
+    expect(result[1]).toEqual({ startMs: 4000, endMs: 6000, title: 'Chorus' });
+  });
 });

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -168,6 +168,67 @@ describe('handleKeydown — markers', () => {
     await flush();
     expect(handler).not.toHaveBeenCalledWith('delete_marker', expect.anything());
   });
+
+  it('x splits a selected startEnd marker', async () => {
+    appState.markers = [{ id: 'b1', position: 3000, kind: 'startEnd' }];
+    appState.renameInputs = { b1: '' };
+    appState.selectedMarkerId = 'b1';
+    let callCount = 0;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return { id: `new${callCount}`, position: 3000, kind: callCount === 1 ? 'end' : 'start' };
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    handleKeydown(keyEvent('x'));
+    for (let i = 0; i < 40; i++) await Promise.resolve();
+    expect(handler).toHaveBeenCalledWith('delete_marker', { id: 'b1' });
+    expect(handler).toHaveBeenCalledWith('add_marker', expect.objectContaining({ kind: 'end' }));
+    expect(handler).toHaveBeenCalledWith('add_marker', expect.objectContaining({ kind: 'start' }));
+  });
+
+  it('X (uppercase) also splits a selected startEnd marker', async () => {
+    appState.markers = [{ id: 'b1', position: 3000, kind: 'startEnd' }];
+    appState.renameInputs = { b1: '' };
+    appState.selectedMarkerId = 'b1';
+    let callCount = 0;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return { id: `new${callCount}`, position: 3000, kind: callCount === 1 ? 'end' : 'start' };
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    handleKeydown(keyEvent('X'));
+    for (let i = 0; i < 40; i++) await Promise.resolve();
+    expect(handler).toHaveBeenCalledWith('delete_marker', { id: 'b1' });
+  });
+
+  it('x does nothing when no marker is selected', async () => {
+    appState.selectedMarkerId = null;
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent('x'));
+    await flush();
+    expect(handler).not.toHaveBeenCalledWith('delete_marker', expect.anything());
+  });
+
+  it('x does nothing when the selected marker is not startEnd', async () => {
+    appState.markers = [{ id: 's1', position: 1000, kind: 'start' }];
+    appState.selectedMarkerId = 's1';
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent('x'));
+    await flush();
+    expect(handler).not.toHaveBeenCalledWith('delete_marker', expect.anything());
+  });
 });
 
 describe('handleKeydown — seeking', () => {

--- a/src/tests/unit/actions.markers.test.ts
+++ b/src/tests/unit/actions.markers.test.ts
@@ -3,7 +3,7 @@ import { mockIPC } from '@tauri-apps/api/mocks';
 import { appState } from '$lib/state.svelte';
 import {
   addMarkerAt, addMarkerNoKind, deleteMarker,
-  renameSegment, computePartialSegments, revalidate,
+  renameSegment, computePartialSegments, revalidate, splitStartEndMarker,
 } from '$lib/actions';
 import { resetAppState } from '../helpers/reset-state';
 import type { Marker } from '$lib/types';
@@ -286,6 +286,123 @@ describe('computePartialSegments', () => {
     expect(segs).toHaveLength(1);
     expect(segs[0].startMs).toBe(1000);
     expect(segs[0].endMs).toBe(5000);
+  });
+
+  it('produces two overlapping segments from start-start-end-end', () => {
+    appState.markers = [
+      marker('s1', 0, 'start'),
+      marker('s2', 1000, 'start'),
+      marker('e1', 4000, 'end'),
+      marker('e2', 5000, 'end'),
+    ];
+    appState.renameInputs = { s1: 'Outer', s2: 'Inner' };
+    const segs = computePartialSegments();
+    expect(segs).toHaveLength(2);
+    // LIFO: s2 closed by e1, s1 closed by e2
+    expect(segs.find(s => s.startMs === 1000)).toEqual({ startMs: 1000, endMs: 4000, title: 'Inner' });
+    expect(segs.find(s => s.startMs === 0)).toEqual({ startMs: 0, endMs: 5000, title: 'Outer' });
+  });
+
+  it('ignores an unmatched outer start when inner segment is complete', () => {
+    appState.markers = [
+      marker('s1', 0, 'start'),
+      marker('s2', 1000, 'start'),
+      marker('e1', 4000, 'end'),
+    ];
+    appState.renameInputs = { s1: 'Outer', s2: 'Inner' };
+    const segs = computePartialSegments();
+    // Only s2→e1 closes; s1 has no matching end so it is left on the stack
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual({ startMs: 1000, endMs: 4000, title: 'Inner' });
+  });
+});
+
+describe('splitStartEndMarker', () => {
+  it('is a no-op when the marker does not exist', async () => {
+    mockIPC(() => undefined);
+    await splitStartEndMarker('nonexistent');
+    expect(appState.markers).toHaveLength(0);
+  });
+
+  it('is a no-op when the marker is not startEnd kind', async () => {
+    appState.markers = [marker('s1', 1000, 'start')];
+    mockIPC(() => undefined);
+    await splitStartEndMarker('s1');
+    expect(appState.markers).toHaveLength(1);
+    expect(appState.markers[0].kind).toBe('start');
+  });
+
+  it('removes the startEnd marker', async () => {
+    appState.markers = [marker('b1', 3000, 'startEnd')];
+    appState.renameInputs = { b1: '' };
+    let callCount = 0;
+    mockIPC((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return marker(`new${callCount}`, 3000, callCount === 1 ? 'end' : 'start');
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await splitStartEndMarker('b1');
+    expect(appState.markers.find(m => m.id === 'b1')).toBeUndefined();
+  });
+
+  it('creates an end and a start marker at the same position', async () => {
+    appState.markers = [marker('b1', 3000, 'startEnd')];
+    appState.renameInputs = { b1: '' };
+    let callCount = 0;
+    mockIPC((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return marker(`new${callCount}`, 3000, callCount === 1 ? 'end' : 'start');
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await splitStartEndMarker('b1');
+    const kinds = appState.markers.map(m => m.kind).sort();
+    expect(kinds).toEqual(['end', 'start']);
+    expect(appState.markers.every(m => m.position === 3000)).toBe(true);
+  });
+
+  it('transfers the title from the startEnd marker to the new start marker', async () => {
+    appState.markers = [marker('b1', 3000, 'startEnd')];
+    appState.renameInputs = { b1: 'Chorus' };
+    let callCount = 0;
+    mockIPC((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return marker(`new${callCount}`, 3000, callCount === 1 ? 'end' : 'start');
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    await splitStartEndMarker('b1');
+    const startMarker = appState.markers.find(m => m.kind === 'start');
+    expect(startMarker).toBeDefined();
+    expect(appState.renameInputs[startMarker!.id]).toBe('Chorus');
+  });
+
+  it('calls revalidate after splitting', async () => {
+    appState.markers = [marker('b1', 3000, 'startEnd')];
+    appState.renameInputs = { b1: '' };
+    let callCount = 0;
+    const handler = vi.fn((cmd: string) => {
+      if (cmd === 'delete_marker') return undefined;
+      if (cmd === 'add_marker') {
+        callCount++;
+        return marker(`new${callCount}`, 3000, callCount === 1 ? 'end' : 'start');
+      }
+      if (cmd === 'validate_markers') return [];
+      return undefined;
+    });
+    mockIPC(handler);
+    await splitStartEndMarker('b1');
+    expect(handler).toHaveBeenCalledWith('validate_markers', expect.anything());
   });
 });
 

--- a/src/tests/unit/actions.playback.test.ts
+++ b/src/tests/unit/actions.playback.test.ts
@@ -167,6 +167,24 @@ describe('exportAudioSegments', () => {
     expect(handler).toHaveBeenCalledWith('export_audio_segments', { exportCsv: true, exportAudio: true });
   });
 
+  it('sets successMessage when both exportCsv and exportAudio are true', async () => {
+    mockIPC(() => undefined);
+    await exportAudioSegments(true, true);
+    expect(appState.successMessage).toBe('CSV and audio segments exported successfully.');
+  });
+
+  it('sets successMessage when only exportCsv is true', async () => {
+    mockIPC(() => undefined);
+    await exportAudioSegments(true, false);
+    expect(appState.successMessage).toBe('CSV exported successfully.');
+  });
+
+  it('sets successMessage when only exportAudio is true', async () => {
+    mockIPC(() => undefined);
+    await exportAudioSegments(false, true);
+    expect(appState.successMessage).toBe('Audio segments exported successfully.');
+  });
+
   it('sets appState.error when invoke throws', async () => {
     mockIPC(() => { throw new Error('export failed'); });
     await exportAudioSegments(true, true);

--- a/src/tests/unit/validation.test.ts
+++ b/src/tests/unit/validation.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { validationProblemMarkerIds } from '$lib/validation';
+import type { Marker } from '$lib/types';
+
+function marker(id: string, position: number, kind: Marker['kind'] = 'start'): Marker {
+  return { id, position, kind };
+}
+
+describe('validationProblemMarkerIds', () => {
+  it('returns an empty set when error is null', () => {
+    const markers = [marker('m1', 1000)];
+    expect(validationProblemMarkerIds(markers, null).size).toBe(0);
+  });
+
+  it('returns an empty set when error does not match any known pattern', () => {
+    const markers = [marker('m1', 1000)];
+    expect(validationProblemMarkerIds(markers, 'some unknown error').size).toBe(0);
+  });
+
+  describe('"no preceding start" errors', () => {
+    it('returns the end marker that has no preceding start', () => {
+      const markers = [marker('e1', 1000, 'end')];
+      const result = validationProblemMarkerIds(markers, 'end marker has no preceding start');
+      expect(result).toEqual(new Set(['e1']));
+    });
+
+    it('does not flag an end marker that has a preceding start', () => {
+      const markers = [marker('s1', 500, 'start'), marker('e1', 1000, 'end')];
+      const result = validationProblemMarkerIds(markers, 'end marker has no preceding start');
+      expect(result.size).toBe(0);
+    });
+
+    it('handles markers given out of order — sorts by position first', () => {
+      const markers = [marker('e1', 1000, 'end'), marker('s1', 500, 'start')];
+      const result = validationProblemMarkerIds(markers, 'end marker has no preceding start');
+      expect(result.size).toBe(0);
+    });
+
+    it('identifies the first orphaned end when a start precedes a different end', () => {
+      const markers = [
+        marker('e0', 200, 'end'),
+        marker('s1', 500, 'start'),
+        marker('e1', 1000, 'end'),
+      ];
+      const result = validationProblemMarkerIds(markers, 'no preceding start marker');
+      expect(result).toEqual(new Set(['e0']));
+    });
+
+    it('a standalone startEnd counts as an open start so a following end is valid', () => {
+      const markers = [marker('b1', 500, 'startEnd'), marker('e1', 1000, 'end')];
+      const result = validationProblemMarkerIds(markers, 'end marker has no preceding start');
+      expect(result.size).toBe(0);
+    });
+
+    it('identifies the orphaned end after a startEnd+end pair has consumed all open starts', () => {
+      const markers = [
+        marker('b1', 500, 'startEnd'),
+        marker('e1', 1000, 'end'),
+        marker('e2', 1500, 'end'),
+      ];
+      const result = validationProblemMarkerIds(markers, 'end marker has no preceding start');
+      expect(result).toEqual(new Set(['e2']));
+    });
+  });
+
+  describe('"unmatched start" errors', () => {
+    it('finds the unmatched start by position from the error message', () => {
+      const markers = [marker('s1', 3000, 'start')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start at position 3000 ms');
+      expect(result).toEqual(new Set(['s1']));
+    });
+
+    it('finds an unmatched startEnd marker by position', () => {
+      const markers = [marker('b1', 5000, 'startEnd')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start at position 5000 ms');
+      expect(result).toEqual(new Set(['b1']));
+    });
+
+    it('falls back to the last start marker when no position is in the error', () => {
+      const markers = [marker('s1', 1000, 'start'), marker('s2', 3000, 'start')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start marker found');
+      expect(result).toEqual(new Set(['s2']));
+    });
+
+    it('falls back to the last startEnd marker when no position in the error', () => {
+      const markers = [marker('b1', 3000, 'startEnd')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start marker found');
+      expect(result).toEqual(new Set(['b1']));
+    });
+
+    it('returns empty set when no start or startEnd exists for fallback', () => {
+      const markers = [marker('e1', 1000, 'end')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start marker found');
+      expect(result.size).toBe(0);
+    });
+
+    it('ignores end markers when searching by position', () => {
+      const markers = [marker('e1', 3000, 'end')];
+      const result = validationProblemMarkerIds(markers, 'unmatched start at position 3000 ms');
+      expect(result.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
This pull request addressed #46. It adds a button (and a shortcut via the X key) to split a selected start/end marker into separate start and end markers. The frontend tests have been updated to reflect this change

Also included in this PR are some changes to the Rust logic that validates the markers. The logic previously required that following a start marker the next marker must be either an end marker or a start/end (segments could not overlap). I changed that logic to allow for overlapping segments if needed using a matching parentheses approach. 