### PR TITLE
Scroll on click and marker colors

### DIFF
--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -290,7 +290,7 @@
 
   .dot-start  { background: #22c55e; }
   .dot-end    { background: #f87171; }
-  .dot-both   { background: #facc15; }
+  .dot-both   { background: linear-gradient(to bottom, #22c55e 0 50%, #f87171 50% 100%); }
 
   .marker-time {
     font-variant-numeric: tabular-nums;

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { appState } from '$lib/state.svelte';
   import { formatMs, parseTimeMs } from '$lib/utils';
-  import { enterEditMode, cancelEditMode, confirmEditMode } from '$lib/actions';
+  import { selectMarker, enterEditMode, cancelEditMode, confirmEditMode } from '$lib/actions';
   import { validationProblemMarkerIds } from '$lib/validation';
   import type { MarkerKind } from '$lib/types';
 
@@ -70,10 +70,10 @@
           class:marker-row-editing={appState.editingMarkerId === m.id}
           class:marker-row-validation-error={validationProblemIds.has(m.id)}
           data-marker-id={m.id}
-          onclick={() => { appState.selectedMarkerId = m.id; }}
+          onclick={() => { selectMarker(m.id); }}
           role="button"
           tabindex="0"
-          onkeydown={(e) => { if (e.key === 'Enter') appState.selectedMarkerId = m.id; }}
+          onkeydown={(e) => { if (e.key === 'Enter') selectMarker(m.id); }}
         >
           <span
             class="marker-dot"

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -185,6 +185,9 @@
       {:else}
         <div
           class="marker-line"
+          class:marker-start={m.kind === 'start'}
+          class:marker-end={m.kind === 'end'}
+          class:marker-both={m.kind === 'startEnd'}
           class:marker-selected={appState.selectedMarkerId === m.id}
           class:marker-validation-error={validationProblemIds.has(m.id)}
           style="left: {origPct}%"
@@ -267,22 +270,30 @@
     transition: opacity 0.1s;
   }
 
+  .marker-line.marker-start {
+    background: #22c55e;
+  }
+
+  .marker-line.marker-end {
+    background: #f87171;
+  }
+
+  .marker-line.marker-both {
+    background: linear-gradient(to bottom, #22c55e 0 50%, #f87171 50% 100%);
+  }
+
   .marker-line.marker-selected {
-    background: #facc15;
     opacity: 1;
-    width: 2px;
-    box-shadow: 0 0 6px #facc15;
   }
 
   .marker-line.marker-ghost {
-    background: #22c55e;
+    background: #f97316;
     opacity: 0.3;
   }
 
   .marker-line.marker-editing {
     background: #f97316;
     opacity: 1;
-    box-shadow: 0 0 8px #f97316;
     animation: editing-pulse 1s ease-in-out infinite alternate;
   }
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -137,7 +137,17 @@ export function handleKeydown(e: KeyboardEvent) {
 
 // ── Seeking ───────────────────────────────────────────────────────────────
 
-export async function seekTo(ms: number) {
+export function centerWaveformAt(ms: number) {
+  const wrap = appState.waveformWrapEl;
+  if (!wrap || appState.zoomLevel <= 1 || appState.durationMs <= 0) return;
+
+  const pct = ms / appState.durationMs;
+  const total = wrap.scrollWidth;
+  const visible = wrap.clientWidth;
+  wrap.scrollLeft = Math.max(0, pct * total - visible / 2);
+}
+
+export async function seekTo(ms: number, options: { centerWaveform?: boolean } = {}) {
   try {
     await invoke('seek', { positionMs: Math.round(ms) });
     appState.positionMs     = ms;
@@ -146,17 +156,20 @@ export async function seekTo(ms: number) {
     if (appState.wavesurfer && appState.durationMs > 0) {
       appState.wavesurfer.setTime(ms / 1000);
     }
-    // Scroll waveform to keep the new position visible when zoomed
-    const wrap = appState.waveformWrapEl;
-    if (wrap && appState.zoomLevel > 1 && appState.durationMs > 0 && appState.followPlayhead) {
-      const pct     = ms / appState.durationMs;
-      const total   = wrap.scrollWidth;
-      const visible = wrap.clientWidth;
-      wrap.scrollLeft = Math.max(0, pct * total - visible / 2);
+    if (options.centerWaveform || appState.followPlayhead) {
+      centerWaveformAt(ms);
     }
   } catch (e) {
     appState.error = String(e);
   }
+}
+
+export async function selectMarker(id: string) {
+  const marker = appState.markers.find(m => m.id === id);
+  if (!marker) return;
+
+  appState.selectedMarkerId = marker.id;
+  await seekTo(marker.position, { centerWaveform: true });
 }
 
 export async function seekToPrevMarker() {
@@ -164,8 +177,7 @@ export async function seekToPrevMarker() {
     .filter(m => m.position < appState.positionMs - 50)
     .sort((a, b) => b.position - a.position)[0];
   if (prev) {
-    appState.selectedMarkerId = prev.id;
-    await seekTo(prev.position);
+    await selectMarker(prev.id);
   }
 }
 
@@ -174,8 +186,7 @@ export async function seekToNextMarker() {
     .filter(m => m.position > appState.positionMs + 50)
     .sort((a, b) => a.position - b.position)[0];
   if (next) {
-    appState.selectedMarkerId = next.id;
-    await seekTo(next.position);
+    await selectMarker(next.id);
   }
 }
 

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -255,19 +255,23 @@ describe('handleKeydown — seeking', () => {
   it('d seeks to the previous marker', async () => {
     appState.markers = [{ id: 'a', position: 2000, kind: 'start' }];
     appState.positionMs = 5000;
+    appState.durationMs = 10_000;
     mockIPC(() => undefined);
     handleKeydown(keyEvent('d'));
     await flush();
     expect(appState.positionMs).toBe(2000);
+    expect(appState.selectedMarkerId).toBe('a');
   });
 
   it('f seeks to the next marker', async () => {
     appState.markers = [{ id: 'a', position: 8000, kind: 'end' }];
     appState.positionMs = 5000;
+    appState.durationMs = 10_000;
     mockIPC(() => undefined);
     handleKeydown(keyEvent('f'));
     await flush();
     expect(appState.positionMs).toBe(8000);
+    expect(appState.selectedMarkerId).toBe('a');
   });
 });
 

--- a/src/tests/unit/actions.seeking.test.ts
+++ b/src/tests/unit/actions.seeking.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import { appState } from '$lib/state.svelte';
-import { seekTo, seekToPrevMarker, seekToNextMarker, stepBack, stepFwd, handleFollowPlayhead } from '$lib/actions';
+import { seekTo, selectMarker, seekToPrevMarker, seekToNextMarker, stepBack, stepFwd, handleFollowPlayhead } from '$lib/actions';
 import { resetAppState } from '../helpers/reset-state';
 import type { Marker } from '$lib/types';
 
@@ -89,6 +89,19 @@ describe('seekToPrevMarker', () => {
     expect(appState.selectedMarkerId).toBe('b');
   });
 
+  it('centers the previous marker when zoomed', async () => {
+    mockIPC(() => undefined);
+    const wrap = makeWrapEl(1000, 200);
+    appState.markers = [marker('a', 5000)];
+    appState.positionMs = 8000;
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    appState.followPlayhead = false;
+    await seekToPrevMarker();
+    expect(wrap.scrollLeft).toBe(400);
+  });
+
   it('does not change selectedMarkerId when no previous marker exists', async () => {
     mockIPC(() => undefined);
     appState.markers = [marker('a', 8000)];
@@ -130,6 +143,19 @@ describe('seekToNextMarker', () => {
     appState.positionMs = 5000;
     await seekToNextMarker();
     expect(appState.selectedMarkerId).toBe('a');
+  });
+
+  it('centers the next marker when zoomed', async () => {
+    mockIPC(() => undefined);
+    const wrap = makeWrapEl(1000, 200);
+    appState.markers = [marker('a', 5000)];
+    appState.positionMs = 1000;
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    appState.followPlayhead = false;
+    await seekToNextMarker();
+    expect(wrap.scrollLeft).toBe(400);
   });
 
   it('does not change selectedMarkerId when no next marker exists', async () => {
@@ -207,7 +233,7 @@ describe('seekTo — waveform scroll sync', () => {
     appState.waveformWrapEl = wrap;
     appState.zoomLevel = 2;
     appState.durationMs = 10_000;
-    appState.followPlayhead = true
+    appState.followPlayhead = true;
     await seekTo(5000);
     expect(wrap.scrollLeft).toBe(400);
   });
@@ -219,6 +245,7 @@ describe('seekTo — waveform scroll sync', () => {
     appState.waveformWrapEl = wrap;
     appState.zoomLevel = 2;
     appState.durationMs = 10_000;
+    appState.followPlayhead = true;
     await seekTo(100);
     expect(wrap.scrollLeft).toBe(0);
   });
@@ -265,6 +292,39 @@ describe('seekTo — followPlayhead', () => {
     appState.followPlayhead = true;
     await seekTo(5000);
     expect(wrap.scrollLeft).toBe(400);
+  });
+});
+
+describe('selectMarker', () => {
+  it('selects and seeks to the marker', async () => {
+    mockIPC(() => undefined);
+    appState.markers = [marker('a', 3000)];
+    appState.durationMs = 10_000;
+    await selectMarker('a');
+    expect(appState.selectedMarkerId).toBe('a');
+    expect(appState.positionMs).toBe(3000);
+  });
+
+  it('centers the marker when zoomed even if followPlayhead is false', async () => {
+    mockIPC(() => undefined);
+    const wrap = makeWrapEl(1000, 200);
+    appState.markers = [marker('a', 5000)];
+    appState.waveformWrapEl = wrap;
+    appState.zoomLevel = 2;
+    appState.durationMs = 10_000;
+    appState.followPlayhead = false;
+    await selectMarker('a');
+    expect(wrap.scrollLeft).toBe(400);
+  });
+
+  it('does nothing when the marker does not exist', async () => {
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    appState.markers = [marker('a', 3000)];
+    appState.durationMs = 10_000;
+    await selectMarker('missing');
+    expect(appState.selectedMarkerId).toBeNull();
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
This PR attempts to address issues #44 and #45. 

When waveform zoom is > 1, selecting a marker by clicking in the marker panel or via the D/F shortcuts moves the playhead and waveform display such that the selected marker is centered. 

Additionally, start and end markers have been colored green and red respectively, and start+end markers are a horizontal gradient of green to red--markers with the edit state toggled remain orange. 