### PR TITLE
Feature/jb/modify marker by click

### DIFF
--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -4,6 +4,7 @@
   import { appState } from '$lib/state.svelte';
   import { kindLabel, formatMs, ZOOM_LEVELS } from '$lib/utils';
   import { validationProblemMarkerIds } from '$lib/validation';
+  import { moveEditingMarkerToMs } from '$lib/actions';
 
   let waveformEl     = $state<HTMLDivElement | null>(null);
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
@@ -76,8 +77,16 @@
 
   // ── Waveform drag seeking ──────────────────────────────────────────────
   // We own pointer events on the container so the playhead moves in real-time.
+  //
+  // editDragging tracks a pointer-down that started while a marker was being
+  // edited.  It is intentionally separate from appState.waveformDragging so
+  // that confirmEditMode() (triggered by Enter) cannot clear it: if the user
+  // presses Enter while still holding the mouse, the subsequent pointer-up must
+  // still be handled as an edit drag — not fall through to the seek path and
+  // snap the playhead to the mouse position.
 
   let waveformWasPlaying = false;
+  let editDragging = false;
 
   function waveformPosFromEvent(e: PointerEvent): number {
     if (!waveformEl) return 0;
@@ -92,28 +101,44 @@
     if (!appState.metadata || appState.durationMs === 0) return;
     e.preventDefault();
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    const ms = waveformPosFromEvent(e);
+    if (appState.editingMarkerId) {
+      editDragging = true;
+      appState.waveformDragging = true;
+      moveEditingMarkerToMs(ms);
+      return;
+    }
     appState.waveformDragging = true;
     waveformWasPlaying = appState.isPlaying;
     if (appState.isPlaying) {
       appState.isPlaying = false;
       invoke('pause').catch(() => {});
     }
-    const ms = waveformPosFromEvent(e);
     appState.positionMs = ms;
     if (appState.wavesurfer) appState.wavesurfer.setTime(ms / 1000);
   }
 
   function handlePointerMove(e: PointerEvent) {
-    if (!appState.waveformDragging) return;
     const ms = waveformPosFromEvent(e);
+    if (editDragging) {
+      moveEditingMarkerToMs(ms);
+      return;
+    }
+    if (!appState.waveformDragging) return;
     appState.positionMs = ms;
     if (appState.wavesurfer) appState.wavesurfer.setTime(ms / 1000);
   }
 
   async function handlePointerUp(e: PointerEvent) {
+    const ms = waveformPosFromEvent(e);
+    if (editDragging) {
+      editDragging = false;
+      appState.waveformDragging = false;
+      moveEditingMarkerToMs(ms);
+      return;
+    }
     if (!appState.waveformDragging) return;
     appState.waveformDragging = false;
-    const ms = waveformPosFromEvent(e);
     appState.positionMs    = ms;
     appState.syncPositionMs = ms;
     appState.syncWallTime   = performance.now();
@@ -148,6 +173,7 @@
 
 <div
   class="waveform-wrap"
+  class:waveform-editing={!!appState.editingMarkerId}
   bind:this={waveformWrapEl}
   role="slider"
   aria-label="Playback position"
@@ -160,6 +186,9 @@
   onpointerup={handlePointerUp}
   onpointercancel={handlePointerUp}
 >
+  {#if appState.editingMarkerId}
+    <div class="edit-mode-hint">Click to move marker · Enter to confirm · Esc to cancel</div>
+  {/if}
   <div class="waveform-scroll" style="width: {appState.zoomLevel * 100}%">
     <div class="waveform-inner" bind:this={waveformEl}></div>
     <!-- Marker overlays — left: pct% is relative to waveform-scroll, same width as the waveform -->
@@ -244,6 +273,28 @@
     border-bottom: 1px solid #21262d;
     overflow-x: auto;
     overflow-y: hidden;
+  }
+
+  .waveform-wrap.waveform-editing {
+    cursor: crosshair;
+    outline: 2px solid #f97316;
+    outline-offset: -2px;
+  }
+
+  .edit-mode-hint {
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 20;
+    background: rgba(249, 115, 22, 0.85);
+    color: #fff;
+    font-size: 11px;
+    padding: 2px 10px;
+    border-radius: 4px;
+    pointer-events: none;
+    white-space: nowrap;
+    user-select: none;
   }
 
   .waveform-scroll {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -167,7 +167,8 @@ export async function seekTo(ms: number, options: { centerWaveform?: boolean } =
 export async function selectMarker(id: string) {
   const marker = appState.markers.find(m => m.id === id);
   if (!marker) return;
-  if (appState.selectedMarkerId === appState.editingMarkerId) return;
+  if (appState.selectedMarkerId === appState.editingMarkerId 
+    && appState.selectedMarkerId !== null) return;
 
   appState.selectedMarkerId = marker.id;
   await seekTo(marker.position, { centerWaveform: true });

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -167,6 +167,7 @@ export async function seekTo(ms: number, options: { centerWaveform?: boolean } =
 export async function selectMarker(id: string) {
   const marker = appState.markers.find(m => m.id === id);
   if (!marker) return;
+  if (appState.selectedMarkerId === appState.editingMarkerId) return;
 
   appState.selectedMarkerId = marker.id;
   await seekTo(marker.position, { centerWaveform: true });
@@ -366,6 +367,11 @@ export async function confirmEditMode() {
   } catch (e) {
     appState.error = String(e);
   }
+}
+
+export function moveEditingMarkerToMs(ms: number) {
+  if (!appState.editingMarkerId) return;
+  appState.editingPositionMs = Math.max(0, Math.min(ms, appState.durationMs));
 }
 
 export function nudgeMarker(direction: -1 | 1) {

--- a/src/tests/unit/actions.editing.test.ts
+++ b/src/tests/unit/actions.editing.test.ts
@@ -6,6 +6,7 @@ import {
   cancelEditMode,
   confirmEditMode,
   nudgeMarker,
+  moveEditingMarkerToMs,
   computePreviewSegments,
 } from '$lib/actions';
 import { resetAppState } from '../helpers/reset-state';
@@ -186,6 +187,29 @@ describe('confirmEditMode', () => {
     await confirmEditMode();
     expect(appState.error).toMatch('move failed');
   });
+
+  it('does not move the playhead when confirmed after a waveform click', async () => {
+    // Regression: when the user clicks the waveform to reposition a marker and
+    // then presses Enter, confirmEditMode must not touch positionMs.  The bug
+    // was that the waveform pointer-down handler set waveformDragging=true before
+    // the edit-mode early-return; if Enter was pressed while the pointer was still
+    // captured, handlePointerUp fired after editingMarkerId was already null and
+    // fell through to the seek path, snapping the playhead to the mouse position.
+    appState.markers = [marker('m1', 3000)];
+    appState.positionMs = 15_000; // playhead far from the marker
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 8_000; // moved to new position via waveform click
+    // Simulate the race-condition state: pointer is still captured (dragging=true)
+    // even though confirmEditMode is about to run
+    appState.waveformDragging = true;
+    mockIPC((cmd: string) => (cmd === 'validate_markers' ? [] : undefined));
+    await confirmEditMode();
+    // positionMs must not have changed regardless of waveformDragging state
+    expect(appState.positionMs).toBe(15_000);
+    // waveformDragging must also have been left alone by confirmEditMode
+    // (the component's pointer-up handler is responsible for clearing it)
+    expect(appState.waveformDragging).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -251,6 +275,75 @@ describe('nudgeMarker', () => {
     nudgeMarker(-1);
     // After auto-entry, editingPositionMs starts at 3000 then nudges -100
     expect(appState.editingPositionMs).toBe(2900);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveEditingMarkerToMs
+// ---------------------------------------------------------------------------
+
+describe('moveEditingMarkerToMs', () => {
+  it('does nothing when not in edit mode', () => {
+    appState.editingMarkerId = null;
+    appState.editingPositionMs = 0;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(5000);
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('updates editingPositionMs to the given value when in edit mode', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(8000);
+    expect(appState.editingPositionMs).toBe(8000);
+  });
+
+  it('clamps to 0 when given a negative value', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(-500);
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('clamps to durationMs when given a value past the end', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(99_000);
+    expect(appState.editingPositionMs).toBe(60_000);
+  });
+
+  it('accepts a value exactly at 0', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(0);
+    expect(appState.editingPositionMs).toBe(0);
+  });
+
+  it('accepts a value exactly at durationMs', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(60_000);
+    expect(appState.editingPositionMs).toBe(60_000);
+  });
+
+  it('does not alter positionMs (playback position)', () => {
+    appState.markers = [marker('m1', 3000)];
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 3000;
+    appState.positionMs = 1000;
+    appState.durationMs = 60_000;
+    moveEditingMarkerToMs(20_000);
+    expect(appState.positionMs).toBe(1000);
   });
 });
 


### PR DESCRIPTION
This PR addresses #47, giving the user the ability to click on the waveform while editing a marker to move it to the desired location. 