### PR TITLE
Add shortcuts to seek to start/end of file

### DIFF
--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -39,22 +39,24 @@
           ms
         </span>
       </div>
-      <div class="shortcut-row"><kbd>1–5</kbd><span>Playback Speed</span></div>
+      <div class="shortcut-row"><kbd>↑</kbd><span>Seek to end</span></div>
+      <div class="shortcut-row"><kbd>↓</kbd><span>Seek to start</span></div>
+      <div class="shortcut-row"><kbd>1–5</kbd><span>Playback speed</span></div>
 
       <div class="shortcut-subheading">Waveform Zoom</div>
       <div class="shortcut-row"><kbd>-</kbd><span>Zoom out</span></div>
       <div class="shortcut-row"><kbd>+</kbd><span>Zoom in</span></div>
 
       <div class="shortcut-subheading">Add Marker</div>
-      <div class="shortcut-row"><kbd>S</kbd><span>Start</span></div>
-      <div class="shortcut-row"><kbd>E</kbd><span>End</span></div>
-      <div class="shortcut-row"><kbd>B</kbd><span>Start+End</span></div>
+      <div class="shortcut-row"><kbd>S</kbd><span>Add start</span></div>
+      <div class="shortcut-row"><kbd>E</kbd><span>Add end</span></div>
+      <div class="shortcut-row"><kbd>B</kbd><span>Add start+end</span></div>
 
       <div class="shortcut-subheading">Manage Markers</div>
-      <div class="shortcut-row"><kbd>D</kbd><span>Previous Marker</span></div>
-      <div class="shortcut-row"><kbd>F</kbd><span>Next Marker</span></div>
-      <div class="shortcut-row"><kbd>X</kbd><span>Split Start+End Marker</span></div>
-      <div class="shortcut-row"><kbd>Del</kbd><span>Delete Selected Marker</span></div>
+      <div class="shortcut-row"><kbd>D</kbd><span>Seek to previous</span></div>
+      <div class="shortcut-row"><kbd>F</kbd><span>Seek to next</span></div>
+      <div class="shortcut-row"><kbd>X</kbd><span>Split start+end</span></div>
+      <div class="shortcut-row"><kbd>Del</kbd><span>Delete selected</span></div>
 
       <div class="shortcut-subheading">Edit Marker</div>
       <div class="shortcut-row"><kbd>[</kbd><span>Nudge left 100ms</span></div>
@@ -112,8 +114,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 18px;
+    height: 18px;
     flex: 0 0 24px;
     background: #1e2a3a;
     border: 1px solid #30363d;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -114,6 +114,12 @@ export function handleKeydown(e: KeyboardEvent) {
   } else if (e.key === 'ArrowLeft') {
     e.preventDefault();
     stepBack();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    seekToEnd()
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    seekToStart()
   } else if (e.key === 'd' || e.key === 'D') {
     e.preventDefault();
     seekToPrevMarker();
@@ -188,6 +194,14 @@ export async function seekToNextMarker() {
   if (next) {
     await selectMarker(next.id);
   }
+}
+
+export async function seekToStart() {
+  await seekTo(0);
+}
+
+export async function seekToEnd() {
+  await seekTo(appState.durationMs);
 }
 
 export async function stepBack() {

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -252,6 +252,26 @@ describe('handleKeydown — seeking', () => {
     expect(appState.positionMs).toBe(5000);
   });
 
+  it('ArrowUp calls seekToEnd', async () => {
+    appState.positionMs = 10_000;
+    appState.stepMs = 5000;
+    appState.durationMs = 60_000;
+    mockIPC(() => undefined);
+    handleKeydown(keyEvent('ArrowUp'));
+    await flush();
+    expect(appState.positionMs).toBe(60_000);
+  });
+
+  it('ArrowDown calls seekToStart', async () => {
+    appState.positionMs = 10_000;
+    appState.stepMs = 5000;
+    appState.durationMs = 60_000;
+    mockIPC(() => undefined);
+    handleKeydown(keyEvent('ArrowDown'));
+    await flush();
+    expect(appState.positionMs).toBe(0);
+  });
+
   it('d seeks to the previous marker', async () => {
     appState.markers = [{ id: 'a', position: 2000, kind: 'start' }];
     appState.positionMs = 5000;


### PR DESCRIPTION
This pull request addresses issue #48 by adding new shortcuts to jump to the start and end of the file.

In this PR I also modified the size of the collapse shortcuts button such that the shortcuts section header is on the same plane as the header for the marker and segments sections