### PR TITLE
Add shortcut customization

### DIFF
--- a/docs/user-documentation/index.md
+++ b/docs/user-documentation/index.md
@@ -36,33 +36,7 @@ In the segment list the user can see all of the valid segments formed by the cur
 
 ### Shortcut List 
 
-This section lists all of the shortcuts provided to the user for easy reference. Some shortcuts, such as the seek shortcut used by the arrow keys, can be configured to use different values or timesteps. Refer to the [Keyboard Shortcuts](#keyboard-shortcuts) section for a comprehensive list of the available shortcuts. 
-
-## Keyboard Shortcuts
-
-| Shortcut | Action |
-|---|---|
-| `Space` | Play / Pause |
-| `←` | Seek backwards (configurable step) |
-| `→` | Seek forwards (configurable step) |
-| `1` | Set playback speed to 0.5× |
-| `2` | Set playback speed to 0.75× |
-| `3` | Set playback speed to 1× |
-| `4` | Set playback speed to 1.5× |
-| `5` | Set playback speed to 2× |
-| `-` | Zoom out |
-| `+` / `=` | Zoom in |
-| `S` | Add start marker at current position |
-| `E` | Add end marker at current position |
-| `B` | Add start/end marker at current position |
-| `D` | Seek to previous marker |
-| `F` | Seek to next marker |
-| `[` | Nudge selected marker left by 100 ms |
-| `]` | Nudge selected marker right by 100 ms |
-| `Enter` | Confirm marker position edit |
-| `Escape` | Cancel marker position edit |
-| `Delete` / `Backspace` | Delete selected marker |
-| `Ctrl+E` / `Cmd+E` | Export markers as CSV |
+This section lists all of the shortcuts provided to the user for easy reference. Some shortcuts, such as the seek shortcut used by the arrow keys, can be configured to use different values or timesteps. Refer to the [Keyboard Shortcuts](shortcuts.md) page for a comprehensive list of the available shortcuts as well as instructions on how to modify their bindings. 
 
 ## Supported Audio File Formats
 

--- a/docs/user-documentation/shortcuts.md
+++ b/docs/user-documentation/shortcuts.md
@@ -1,0 +1,42 @@
+# Shortcuts
+
+Shortcuts are provided for the majority of the functionality within the app. Users can modify the keys binded to each shortcut by following the process below:
+
+1. press the "edit" button at the top of the shortcuts section
+2. click on the current binding for the shortcut you would like to modify the binding for
+3. press the button on your keyboard you would like to bind to that shortcut 
+4. click "done" at the top of the shortcuts section to save the change.
+
+If the user modifies the keyboard bindings and would like to revert them back to the defaults, they can enter edit mode and scroll to the bottom of the section then press the "Reset to Defaults" button.
+
+## Keyboard Shortcuts
+
+The default shortcuts and keybindings provided within the app are as follows:
+
+| Shortcut | Action |
+|---|---|
+| `Space` | Play / Pause |
+| `L` | Toggle follow playhead |
+| `←` | Seek backwards (configurable step) |
+| `→` | Seek forwards (configurable step) |
+| `↑` | Seek to end of file |
+| `↓` | Seek to start of file |
+| `1` | Set playback speed to 0.5× |
+| `2` | Set playback speed to 0.75× |
+| `3` | Set playback speed to 1× |
+| `4` | Set playback speed to 1.5× |
+| `5` | Set playback speed to 2× |
+| `-` | Zoom out |
+| `+` / `=` | Zoom in |
+| `S` | Add start marker at current position |
+| `E` | Add end marker at current position |
+| `B` | Add start/end marker at current position |
+| `X` | Split start/end marker at current position |
+| `D` | Seek to previous marker |
+| `F` | Seek to next marker |
+| `[` | Nudge selected marker left by 100 ms |
+| `]` | Nudge selected marker right by 100 ms |
+| `Enter` | Confirm marker position edit |
+| `Escape` | Cancel marker position edit |
+| `Delete` / `Backspace` | Delete selected marker |
+| `Ctrl+E` / `Cmd+E` | Export markers as CSV |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use uuid::Uuid;
 
 use crate::audio::{AudioEngine, FileMetadata};
@@ -303,6 +303,35 @@ pub async fn export_audio_segments(
         .ok_or_else(|| AppError::ValidationError("Invalid output directory path".into()))?;
 
     export_segments(&app, &source_path, &segments, output_path, export_csv, export_audio).await
+}
+
+// ---------------------------------------------------------------------------
+// Shortcuts config
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn read_shortcuts_config(app: AppHandle) -> Result<Option<String>> {
+    let config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+    let path = config_dir.join("shortcuts.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)?;
+    Ok(Some(content))
+}
+
+#[tauri::command]
+pub fn write_shortcuts_config(app: AppHandle, config: String) -> Result<()> {
+    let config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+    std::fs::create_dir_all(&config_dir)?;
+    std::fs::write(config_dir.join("shortcuts.json"), config)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub fn run() {
             commands::validate_markers,
             commands::import_csv,
             commands::export_audio_segments,
+            commands::read_shortcuts_config,
+            commands::write_shortcuts_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -3,6 +3,7 @@
   import { appState } from '$lib/state.svelte';
   import { formatMs, parseTimeMs } from '$lib/utils';
   import { selectMarker, enterEditMode, cancelEditMode, confirmEditMode } from '$lib/actions';
+  import { formatShortcutKey } from '$lib/shortcuts';
   import { validationProblemMarkerIds } from '$lib/validation';
   import type { MarkerKind } from '$lib/types';
 
@@ -59,7 +60,7 @@
 
   {#if appState.markers.length === 0}
     <p class="empty-state">
-      No markers yet. Use the Add Marker button or press <kbd>S</kbd>, <kbd>E</kbd>, or <kbd>B</kbd>.
+      No markers yet. Use the Add Marker button or press <kbd>{formatShortcutKey(appState.shortcuts.addStartMarker[0])}</kbd>, <kbd>{formatShortcutKey(appState.shortcuts.addEndMarker[0])}</kbd>, or <kbd>{formatShortcutKey(appState.shortcuts.addStartEndMarker[0])}</kbd>.
     </p>
   {:else}
     <div class="marker-list" bind:this={markerListEl}>

--- a/src/components/ShortcutsPanel.svelte
+++ b/src/components/ShortcutsPanel.svelte
@@ -1,10 +1,146 @@
 <script lang="ts">
   import { appState } from '$lib/state.svelte';
+  import {
+    ACTION_NAMES,
+    DEFAULT_SHORTCUTS,
+    formatShortcutKey,
+    matchesShortcut,
+  } from '$lib/shortcuts';
+  import type { ActionName, ShortcutKey } from '$lib/shortcuts';
+  import { saveShortcuts } from '$lib/actions';
 
   let { collapsed = false, onToggleCollapsed }: {
     collapsed?: boolean;
     onToggleCollapsed?: () => void;
   } = $props();
+
+  let editMode = $state(false);
+
+  interface CaptureTarget {
+    action: ActionName;
+    index: number; // -1 = add new, >=0 = replace existing
+  }
+  let capturing = $state<CaptureTarget | null>(null);
+  let conflictAction = $state<ActionName | null>(null);
+  let conflictTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Document-level listener active only while capturing — fires before the
+  // global handleKeydown so we can intercept the keypress.
+  $effect(() => {
+    if (!capturing) return;
+
+    function onKeydown(e: KeyboardEvent) {
+      if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const cap = capturing;
+      if (!cap) return;
+
+      const newKey: ShortcutKey = {
+        key: e.key,
+        ...(e.ctrlKey || e.metaKey ? { ctrl: true } : {}),
+        ...(e.shiftKey ? { shift: true } : {}),
+        ...(e.altKey ? { alt: true } : {}),
+      };
+
+      const conflict = ACTION_NAMES.find(
+        a => a !== cap.action && matchesShortcut(e, appState.shortcuts[a])
+      );
+
+      if (conflict) {
+        conflictAction = conflict;
+        if (conflictTimer) clearTimeout(conflictTimer);
+        conflictTimer = setTimeout(() => { conflictAction = null; }, 2000);
+        capturing = null;
+        return;
+      }
+
+      const current = appState.shortcuts[cap.action];
+      const updated =
+        cap.index === -1
+          ? [...current, newKey]
+          : current.map((k, i) => (i === cap.index ? newKey : k));
+
+      appState.shortcuts = { ...appState.shortcuts, [cap.action]: updated };
+      saveShortcuts(appState.shortcuts);
+      capturing = null;
+    }
+
+    document.addEventListener('keydown', onKeydown, true);
+    return () => document.removeEventListener('keydown', onKeydown, true);
+  });
+
+  interface ShortcutRow {
+    section: string;
+    action: ActionName;
+    label: string;
+  }
+
+  const ROWS: ShortcutRow[] = [
+    { section: 'Control Playback', action: 'stepForward',          label: 'Seek forward' },
+    { section: 'Control Playback', action: 'stepBackward',         label: 'Seek backward' },
+    { section: 'Control Playback', action: 'togglePlay',           label: 'Play/Pause' },
+    { section: 'Control Playback', action: 'seekToEnd',            label: 'Seek to end' },
+    { section: 'Control Playback', action: 'seekToStart',          label: 'Seek to start' },
+    { section: 'Control Playback', action: 'setSpeed1',            label: 'Speed 0.5×' },
+    { section: 'Control Playback', action: 'setSpeed2',            label: 'Speed 0.75×' },
+    { section: 'Control Playback', action: 'setSpeed3',            label: 'Speed 1×' },
+    { section: 'Control Playback', action: 'setSpeed4',            label: 'Speed 1.5×' },
+    { section: 'Control Playback', action: 'setSpeed5',            label: 'Speed 2×' },
+    { section: 'Waveform Zoom',    action: 'zoomOut',              label: 'Zoom out' },
+    { section: 'Waveform Zoom',    action: 'zoomIn',               label: 'Zoom in' },
+    { section: 'Waveform Zoom',    action: 'toggleFollowPlayhead', label: 'Follow playhead' },
+    { section: 'Add Marker',       action: 'addStartMarker',       label: 'Add start' },
+    { section: 'Add Marker',       action: 'addEndMarker',         label: 'Add end' },
+    { section: 'Add Marker',       action: 'addStartEndMarker',    label: 'Add start+end' },
+    { section: 'Manage Markers',   action: 'seekToPrevMarker',     label: 'Seek to previous' },
+    { section: 'Manage Markers',   action: 'seekToNextMarker',     label: 'Seek to next' },
+    { section: 'Manage Markers',   action: 'splitStartEndMarker',  label: 'Split start+end' },
+    { section: 'Manage Markers',   action: 'deleteMarker',         label: 'Delete selected' },
+    { section: 'Edit Marker',      action: 'nudgeLeft',            label: 'Nudge left 100ms' },
+    { section: 'Edit Marker',      action: 'nudgeRight',           label: 'Nudge right 100ms' },
+    { section: 'Edit Marker',      action: 'confirmEdit',          label: 'Confirm position' },
+    { section: 'Edit Marker',      action: 'cancelEdit',           label: 'Cancel editing' },
+    { section: 'Export',           action: 'exportCsv',            label: 'Export CSV' },
+  ];
+
+  const SECTIONS = [...new Set(ROWS.map(r => r.section))];
+  function rowsForSection(s: string) { return ROWS.filter(r => r.section === s); }
+
+  function startCapture(action: ActionName, index: number) {
+    capturing = { action, index };
+    conflictAction = null;
+    if (conflictTimer) { clearTimeout(conflictTimer); conflictTimer = null; }
+  }
+
+  function removeBinding(action: ActionName, index: number) {
+    const current = appState.shortcuts[action];
+    if (current.length <= 1) return;
+    appState.shortcuts = { ...appState.shortcuts, [action]: current.filter((_, i) => i !== index) };
+    saveShortcuts(appState.shortcuts);
+  }
+
+  function resetToDefaults() {
+    appState.shortcuts = { ...DEFAULT_SHORTCUTS };
+    saveShortcuts(appState.shortcuts);
+    capturing = null;
+    conflictAction = null;
+  }
+
+  function toggleEditMode() {
+    editMode = !editMode;
+    capturing = null;
+    conflictAction = null;
+  }
+
+  function isCapturing(action: ActionName, index: number) {
+    return capturing?.action === action && capturing?.index === index;
+  }
+
+  const isDefaultConfig = $derived(
+    JSON.stringify(appState.shortcuts) === JSON.stringify(DEFAULT_SHORTCUTS)
+  );
 </script>
 
 <div class="panel shortcuts-panel" class:shortcuts-collapsed={collapsed}>
@@ -18,55 +154,112 @@
         Keyboard Shortcuts
       {/if}
     </h3>
-    <button
-      class="collapse-btn"
-      onclick={onToggleCollapsed}
-      title={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
-      aria-label={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
-    >
-      {collapsed ? '‹' : '›'}
-    </button>
+    <div class="header-actions">
+      {#if !collapsed}
+        <button
+          class="edit-btn"
+          class:active={editMode}
+          onclick={toggleEditMode}
+          title={editMode ? 'Done editing' : 'Edit shortcuts'}
+        >
+          {editMode ? 'Done' : 'Edit'}
+        </button>
+      {/if}
+      <button
+        class="collapse-btn"
+        onclick={() => { if (editMode) toggleEditMode(); onToggleCollapsed?.(); }}
+        title={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
+        aria-label={collapsed ? 'Show keyboard shortcuts' : 'Hide keyboard shortcuts'}
+      >
+        {collapsed ? '‹' : '›'}
+      </button>
+    </div>
   </div>
+
   {#if !collapsed}
     <div class="shortcut-list">
-      <div class="shortcut-subheading">Control Playback</div>
-      <div class="shortcut-row"><kbd>Space</kbd><span>Play/Pause</span></div>
-      <div class="shortcut-row">
-        <kbd>←/→</kbd>
-        <span class="seek-step-label">
-          Seek ±
-          <input class="step-input" type="number" min="100" max="60000" bind:value={appState.stepMs} />
-          ms
-        </span>
-      </div>
-      <div class="shortcut-row"><kbd>↑</kbd><span>Seek to end</span></div>
-      <div class="shortcut-row"><kbd>↓</kbd><span>Seek to start</span></div>
-      <div class="shortcut-row"><kbd>1–5</kbd><span>Playback speed</span></div>
+      {#if conflictAction}
+        <div class="conflict-banner">
+          Already bound to <strong>{ROWS.find(r => r.action === conflictAction)?.label ?? conflictAction}</strong> — choose a different key
+        </div>
+      {/if}
 
-      <div class="shortcut-subheading">Waveform Zoom</div>
-      <div class="shortcut-row"><kbd>-</kbd><span>Zoom out</span></div>
-      <div class="shortcut-row"><kbd>+</kbd><span>Zoom in</span></div>
-      <div class="shortcut-row"><kbd>L</kbd><span>Toggle follow playhead</span></div>
+      {#each SECTIONS as section}
+        <div class="shortcut-subheading">{section}</div>
 
-      <div class="shortcut-subheading">Add Marker</div>
-      <div class="shortcut-row"><kbd>S</kbd><span>Add start</span></div>
-      <div class="shortcut-row"><kbd>E</kbd><span>Add end</span></div>
-      <div class="shortcut-row"><kbd>B</kbd><span>Add start+end</span></div>
+        <!-- Special combined row for seek step (view mode only) -->
+        {#if section === 'Control Playback' && !editMode}
+          <div class="shortcut-row">
+            <div class="key-group">
+              <kbd>{formatShortcutKey(appState.shortcuts.stepBackward[0])}/{formatShortcutKey(appState.shortcuts.stepForward[0])}</kbd>
+            </div>
+            <span class="seek-step-label">
+              Seek ±
+              <input class="step-input" type="number" min="100" max="60000" bind:value={appState.stepMs} />
+              ms
+            </span>
+          </div>
+        {/if}
 
-      <div class="shortcut-subheading">Manage Markers</div>
-      <div class="shortcut-row"><kbd>D</kbd><span>Seek to previous</span></div>
-      <div class="shortcut-row"><kbd>F</kbd><span>Seek to next</span></div>
-      <div class="shortcut-row"><kbd>X</kbd><span>Split start+end</span></div>
-      <div class="shortcut-row"><kbd>Del</kbd><span>Delete selected</span></div>
+        {#each rowsForSection(section).filter(r =>
+          editMode || (r.action !== 'stepForward' && r.action !== 'stepBackward')
+        ) as row}
+          <div class="shortcut-row" class:conflict-row={conflictAction === row.action}>
+            <div class="key-group">
+              {#if editMode}
+                {#each appState.shortcuts[row.action] as key, i}
+                  {#if i > 0}<span class="or-sep">or</span>{/if}
+                  <div class="key-item">
+                    <button
+                      class="capture-btn"
+                      class:capturing={isCapturing(row.action, i)}
+                      class:conflict={conflictAction === row.action}
+                      onclick={() => startCapture(row.action, i)}
+                    >
+                      {isCapturing(row.action, i) ? 'Press a key…' : formatShortcutKey(key)}
+                    </button>
+                    {#if appState.shortcuts[row.action].length > 1}
+                      <button
+                        class="remove-btn"
+                        onclick={() => removeBinding(row.action, i)}
+                        title="Remove this binding"
+                        aria-label="Remove binding"
+                      >×</button>
+                    {/if}
+                  </div>
+                {/each}
+                <button
+                  class="add-btn"
+                  class:capturing={isCapturing(row.action, -1)}
+                  onclick={() => startCapture(row.action, -1)}
+                  title="Add another key binding"
+                >
+                  {isCapturing(row.action, -1) ? 'Press a key…' : '+'}
+                </button>
+              {:else}
+                {#each appState.shortcuts[row.action] as key, i}
+                  {#if i > 0}<span class="or-sep">or</span>{/if}
+                  <kbd>{formatShortcutKey(key)}</kbd>
+                {/each}
+              {/if}
+            </div>
 
-      <div class="shortcut-subheading">Edit Marker</div>
-      <div class="shortcut-row"><kbd>[</kbd><span>Nudge left 100ms</span></div>
-      <div class="shortcut-row"><kbd>]</kbd><span>Nudge right 100ms</span></div>
-      <div class="shortcut-row"><kbd>Enter</kbd><span>Confirm position</span></div>
-      <div class="shortcut-row"><kbd>Esc</kbd><span>Cancel editing</span></div>
+            {#if row.action === 'stepForward' && editMode}
+              <span class="seek-step-label">
+                Seek forward ±
+                <input class="step-input" type="number" min="100" max="60000" bind:value={appState.stepMs} />
+                ms
+              </span>
+            {:else}
+              <span>{row.label}</span>
+            {/if}
+          </div>
+        {/each}
+      {/each}
 
-      <div class="shortcut-subheading">Export</div>
-      <div class="shortcut-row"><kbd>Ctrl+E</kbd><span>Export CSV</span></div>
+      {#if editMode}
+        <button class="reset-btn" class:modified={!isDefaultConfig} onclick={resetToDefaults}>Reset to Defaults</button>
+      {/if}
     </div>
   {/if}
 </div>
@@ -111,6 +304,28 @@
     color: #c9d1d9;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .edit-btn {
+    padding: 2px 8px;
+    background: #1e2a3a;
+    border: 1px solid #30363d;
+    border-radius: 5px;
+    color: #8b949e;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1.6;
+  }
+
+  .edit-btn:hover, .edit-btn.active {
+    color: #e2e8f0;
+    border-color: #2563eb;
+  }
+
   .collapse-btn {
     display: flex;
     align-items: center;
@@ -140,6 +355,7 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overflow-x: auto;
   }
 
   .shortcut-row {
@@ -147,14 +363,31 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
+    min-height: 26px;
+    min-width: max-content;
+    flex-wrap: nowrap;
+  }
+
+  .key-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .key-item {
+    display: flex;
+    align-items: center;
+    gap: 2px;
   }
 
   .shortcut-row kbd {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 44px;
-    padding: 4px 8px;
+    min-width: 36px;
+    padding: 4px 7px;
     background: #1e2a3a;
     border: 1px solid #30363d;
     border-radius: 6px;
@@ -167,6 +400,15 @@
   .shortcut-row span {
     font-size: 12px;
     color: #8b949e;
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .or-sep {
+    font-size: 10px;
+    color: #4b5563;
+    text-align: left;
+    flex-shrink: 0;
   }
 
   .shortcut-subheading {
@@ -183,11 +425,13 @@
     display: flex;
     align-items: center;
     gap: 4px;
+    font-size: 12px;
+    color: #8b949e;
   }
 
   .step-input {
-    width: 80px;
-    padding: 4px 8px;
+    width: 64px;
+    padding: 4px 6px;
     background: #1e2a3a;
     border: 1px solid #30363d;
     border-radius: 5px;
@@ -198,4 +442,128 @@
   }
 
   .step-input:focus { border-color: #2563eb; }
+
+  .capture-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    padding: 4px 7px;
+    background: #1e2a3a;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    font-size: 11px;
+    color: #c9d1d9;
+    font-family: inherit;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .capture-btn:hover {
+    border-color: #2563eb;
+    color: #e2e8f0;
+  }
+
+  /* Border-color animation — no opacity changes so nothing bleeds through */
+  .capture-btn.capturing {
+    background: #1e3a5f;
+    color: #93c5fd;
+    animation: pulse-border 1s ease-in-out infinite;
+  }
+
+  .capture-btn.conflict {
+    border-color: #dc2626;
+    background: #3a1e1e;
+    color: #fca5a5;
+  }
+
+  .remove-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    background: #261919;
+    border: none;
+    border-radius: 3px;
+    color: #7a3e3e;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  .remove-btn:hover {
+    background: #3a1e1e;
+    color: #fca5a5;
+  }
+
+  .add-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 26px;
+    padding: 0 6px;
+    background: transparent;
+    border: 1px dashed #30363d;
+    border-radius: 6px;
+    color: #4b5563;
+    cursor: pointer;
+    font-size: 14px;
+    font-family: inherit;
+    white-space: nowrap;
+  }
+
+  .add-btn:hover {
+    border-color: #2563eb;
+    color: #93c5fd;
+    background: #1e3a5f;
+  }
+
+  .add-btn.capturing {
+    border-style: solid;
+    border-color: #2563eb;
+    background: #1e3a5f;
+    color: #93c5fd;
+    font-size: 11px;
+    animation: pulse-border 1s ease-in-out infinite;
+  }
+
+  .conflict-banner {
+    font-size: 11px;
+    color: #fca5a5;
+    background: #3a1e1e;
+    border: 1px solid #dc2626;
+    border-radius: 5px;
+    padding: 6px 10px;
+    margin-bottom: 4px;
+  }
+
+  .reset-btn {
+    margin-top: 10px;
+    padding: 5px 12px;
+    background: #1e2a3a;
+    border: 1px solid #21262d;
+    border-radius: 5px;
+    color: #4b5563;
+    cursor: pointer;
+    font-size: 11px;
+    align-self: flex-start;
+  }
+
+  .reset-btn.modified {
+    color: #e2e8f0;
+    border-color: #4d6a8a;
+  }
+
+  .reset-btn.modified:hover {
+    color: #fff;
+    border-color: #60a5fa;
+  }
+
+  @keyframes pulse-border {
+    0%, 100% { border-color: #2563eb; }
+    50%       { border-color: #60a5fa; }
+  }
 </style>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import { appState } from './state.svelte';
 import { SPEEDS, ZOOM_LEVELS } from './utils';
+import { DEFAULT_SHORTCUTS, matchesShortcut } from './shortcuts';
+import type { ShortcutConfig } from './shortcuts';
 import type { FileMetadata, PlaybackPosition, Marker, Segment, MarkerKind } from './types';
 
 // ── Position polling + interpolation ─────────────────────────────────────
@@ -59,85 +61,81 @@ export function stopRaf() {
 
 // ── Keyboard shortcuts ────────────────────────────────────────────────────
 
+export async function loadShortcuts(): Promise<void> {
+  try {
+    const raw = await invoke<string | null>('read_shortcuts_config');
+    if (raw) {
+      const saved = JSON.parse(raw) as Partial<ShortcutConfig>;
+      appState.shortcuts = { ...DEFAULT_SHORTCUTS, ...saved };
+    }
+  } catch {
+    // File missing or malformed — keep defaults
+  }
+}
+
+export async function saveShortcuts(config: ShortcutConfig): Promise<void> {
+  await invoke('write_shortcuts_config', { config: JSON.stringify(config) });
+}
+
 export function handleKeydown(e: KeyboardEvent) {
   if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) return;
   if (!appState.metadata) return;
 
-  if (e.key === 'Escape' && appState.editingMarkerId) {
-    e.preventDefault();
-    cancelEditMode();
-    return;
-  }
-  if (e.key === 'Enter' && appState.editingMarkerId) {
-    e.preventDefault();
-    confirmEditMode();
-    return;
+  const s = appState.shortcuts;
+
+  if (appState.editingMarkerId) {
+    if (matchesShortcut(e, s.cancelEdit))  { e.preventDefault(); cancelEditMode(); return; }
+    if (matchesShortcut(e, s.confirmEdit)) { e.preventDefault(); confirmEditMode(); return; }
   }
 
-  if (e.code === 'Space') {
-    e.preventDefault();
-    togglePlay();
-  } else if ((e.ctrlKey || e.metaKey) && e.key === 'e') {
-    e.preventDefault();
-    exportCsv();
-  } else if (e.key === '[') {
-    e.preventDefault();
-    nudgeMarker(-1);
-  } else if (e.key === ']') {
-    e.preventDefault();
-    nudgeMarker(1);
-  } else if (e.key === 's' || e.key === 'S') {
-    e.preventDefault();
-    addMarker('start');
-  } else if (e.key === 'e' || e.key === 'E') {
-    e.preventDefault();
-    addMarker('end');
-  } else if (e.key === 'b' || e.key === 'B') {
-    e.preventDefault();
-    addMarker('startEnd');
-  } else if (e.key === 'x' || e.key === 'X') {
-    if (appState.selectedMarkerId) {
-      const m = appState.markers.find(mk => mk.id === appState.selectedMarkerId);
-      if (m?.kind === 'startEnd') {
-        e.preventDefault();
-        splitStartEndMarker(appState.selectedMarkerId);
-      }
-    }
-  } else if (e.key === 'Delete' || e.key === 'Backspace') {
-    if (appState.selectedMarkerId) {
-      e.preventDefault();
-      deleteMarker(appState.selectedMarkerId);
-    }
-  } else if (e.key === 'ArrowRight') {
-    e.preventDefault();
-    stepFwd();
-  } else if (e.key === 'ArrowLeft') {
-    e.preventDefault();
-    stepBack();
-  } else if (e.key === 'ArrowUp') {
-    e.preventDefault()
-    seekToEnd()
-  } else if (e.key === 'ArrowDown') {
-    e.preventDefault()
-    seekToStart()
-  } else if (e.key === 'l' || e.key === 'L') {
-    e.preventDefault();
-    appState.followPlayhead = !appState.followPlayhead;
-  } else if (e.key === 'd' || e.key === 'D') {
-    e.preventDefault();
-    seekToPrevMarker();
-  } else if (e.key === 'f' || e.key === 'F') {
-    e.preventDefault();
-    seekToNextMarker();
-  } else if (e.key >= '1' && e.key <= '5') {
-    e.preventDefault();
-    const idx = parseInt(e.key) - 1;
-    if (SPEEDS[idx] !== undefined) setSpeed(SPEEDS[idx]);
-  } else if (e.key === '-') {
+  if (matchesShortcut(e, s.togglePlay)) {
+    e.preventDefault(); togglePlay();
+  } else if (matchesShortcut(e, s.exportCsv)) {
+    e.preventDefault(); exportCsv();
+  } else if (matchesShortcut(e, s.nudgeLeft)) {
+    e.preventDefault(); nudgeMarker(-1);
+  } else if (matchesShortcut(e, s.nudgeRight)) {
+    e.preventDefault(); nudgeMarker(1);
+  } else if (matchesShortcut(e, s.addStartMarker)) {
+    e.preventDefault(); addMarker('start');
+  } else if (matchesShortcut(e, s.addEndMarker)) {
+    e.preventDefault(); addMarker('end');
+  } else if (matchesShortcut(e, s.addStartEndMarker)) {
+    e.preventDefault(); addMarker('startEnd');
+  } else if (matchesShortcut(e, s.splitStartEndMarker) && appState.selectedMarkerId) {
+    const m = appState.markers.find(mk => mk.id === appState.selectedMarkerId);
+    if (m?.kind === 'startEnd') { e.preventDefault(); splitStartEndMarker(appState.selectedMarkerId); }
+  } else if (matchesShortcut(e, s.deleteMarker) && appState.selectedMarkerId) {
+    e.preventDefault(); deleteMarker(appState.selectedMarkerId);
+  } else if (matchesShortcut(e, s.stepForward)) {
+    e.preventDefault(); stepFwd();
+  } else if (matchesShortcut(e, s.stepBackward)) {
+    e.preventDefault(); stepBack();
+  } else if (matchesShortcut(e, s.seekToEnd)) {
+    e.preventDefault(); seekToEnd();
+  } else if (matchesShortcut(e, s.seekToStart)) {
+    e.preventDefault(); seekToStart();
+  } else if (matchesShortcut(e, s.toggleFollowPlayhead)) {
+    e.preventDefault(); appState.followPlayhead = !appState.followPlayhead;
+  } else if (matchesShortcut(e, s.seekToPrevMarker)) {
+    e.preventDefault(); seekToPrevMarker();
+  } else if (matchesShortcut(e, s.seekToNextMarker)) {
+    e.preventDefault(); seekToNextMarker();
+  } else if (matchesShortcut(e, s.setSpeed1)) {
+    e.preventDefault(); setSpeed(SPEEDS[0]);
+  } else if (matchesShortcut(e, s.setSpeed2)) {
+    e.preventDefault(); setSpeed(SPEEDS[1]);
+  } else if (matchesShortcut(e, s.setSpeed3)) {
+    e.preventDefault(); setSpeed(SPEEDS[2]);
+  } else if (matchesShortcut(e, s.setSpeed4)) {
+    e.preventDefault(); setSpeed(SPEEDS[3]);
+  } else if (matchesShortcut(e, s.setSpeed5)) {
+    e.preventDefault(); setSpeed(SPEEDS[4]);
+  } else if (matchesShortcut(e, s.zoomOut)) {
     e.preventDefault();
     const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
     if (i > 0) appState.zoomLevel = ZOOM_LEVELS[i - 1];
-  } else if (e.key === '+' || e.key === '=') {
+  } else if (matchesShortcut(e, s.zoomIn)) {
     e.preventDefault();
     const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
     if (i < ZOOM_LEVELS.length - 1) appState.zoomLevel = ZOOM_LEVELS[i + 1];

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,98 @@
+export const ACTION_NAMES = [
+  'togglePlay',
+  'exportCsv',
+  'nudgeLeft',
+  'nudgeRight',
+  'addStartMarker',
+  'addEndMarker',
+  'addStartEndMarker',
+  'splitStartEndMarker',
+  'deleteMarker',
+  'stepForward',
+  'stepBackward',
+  'seekToEnd',
+  'seekToStart',
+  'toggleFollowPlayhead',
+  'seekToPrevMarker',
+  'seekToNextMarker',
+  'setSpeed1',
+  'setSpeed2',
+  'setSpeed3',
+  'setSpeed4',
+  'setSpeed5',
+  'zoomOut',
+  'zoomIn',
+  'cancelEdit',
+  'confirmEdit',
+] as const;
+
+export type ActionName = (typeof ACTION_NAMES)[number];
+
+export interface ShortcutKey {
+  key: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+export type ShortcutConfig = Record<ActionName, ShortcutKey[]>;
+
+export const DEFAULT_SHORTCUTS: ShortcutConfig = {
+  togglePlay:          [{ key: ' ' }],
+  exportCsv:           [{ key: 'e', ctrl: true }],
+  nudgeLeft:           [{ key: '[' }],
+  nudgeRight:          [{ key: ']' }],
+  addStartMarker:      [{ key: 's' }],
+  addEndMarker:        [{ key: 'e' }],
+  addStartEndMarker:   [{ key: 'b' }],
+  splitStartEndMarker: [{ key: 'x' }],
+  deleteMarker:        [{ key: 'Delete' }, { key: 'Backspace' }],
+  stepForward:         [{ key: 'ArrowRight' }],
+  stepBackward:        [{ key: 'ArrowLeft' }],
+  seekToEnd:           [{ key: 'ArrowUp' }],
+  seekToStart:         [{ key: 'ArrowDown' }],
+  toggleFollowPlayhead:[{ key: 'l' }],
+  seekToPrevMarker:    [{ key: 'd' }],
+  seekToNextMarker:    [{ key: 'f' }],
+  setSpeed1:           [{ key: '1' }],
+  setSpeed2:           [{ key: '2' }],
+  setSpeed3:           [{ key: '3' }],
+  setSpeed4:           [{ key: '4' }],
+  setSpeed5:           [{ key: '5' }],
+  zoomOut:             [{ key: '-' }],
+  zoomIn:              [{ key: '=' }, { key: '+' }],
+  cancelEdit:          [{ key: 'Escape' }],
+  confirmEdit:         [{ key: 'Enter' }],
+};
+
+export function matchesShortcut(e: KeyboardEvent, keys: ShortcutKey[]): boolean {
+  const ctrlOrMeta = e.ctrlKey || e.metaKey;
+  return keys.some(k => {
+    if (!!k.ctrl !== ctrlOrMeta) return false;
+    if (!!k.shift !== e.shiftKey) return false;
+    if (!!k.alt !== e.altKey) return false;
+    return e.key.toLowerCase() === k.key.toLowerCase();
+  });
+}
+
+const KEY_DISPLAY: Record<string, string> = {
+  ' ':          'Space',
+  'arrowleft':  '←',
+  'arrowright': '→',
+  'arrowup':    '↑',
+  'arrowdown':  '↓',
+  'escape':     'Esc',
+  'delete':     'Del',
+  'backspace':  'Bksp',
+  'enter':      'Enter',
+};
+
+export function formatShortcutKey(k: ShortcutKey): string {
+  const parts: string[] = [];
+  if (k.ctrl)  parts.push('Ctrl');
+  if (k.shift) parts.push('Shift');
+  if (k.alt)   parts.push('Alt');
+  const display = KEY_DISPLAY[k.key.toLowerCase()] ?? k.key.toUpperCase();
+  parts.push(display);
+  return parts.join('+');
+}

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,5 +1,7 @@
 import type WaveSurfer from 'wavesurfer.js';
 import type { FileMetadata, Marker, Segment } from './types';
+import { DEFAULT_SHORTCUTS } from './shortcuts';
+import type { ShortcutConfig } from './shortcuts';
 
 class AppState {
   // ── Displayed in UI (reactive) ─────────────────────────────────────────
@@ -22,6 +24,7 @@ class AppState {
   editingPositionMs = $state(0);
   nudgeStepMs       = 100;
   unkindedMarkers = $state<Set<string>>(new Set());
+  shortcuts = $state<ShortcutConfig>({ ...DEFAULT_SHORTCUTS });
   // Lets the RAF in +page.svelte skip interpolation during waveform drag
   waveformDragging = $state(false);
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { appState } from '$lib/state.svelte';
   import {
-    stopPolling, stopRaf, handleKeydown,
+    stopPolling, stopRaf, handleKeydown, loadShortcuts,
     openFile, importCsv, togglePlay, setSpeed, handleLoop,
     addMarkerNoKind, addMarkerAt, deleteMarker, splitStartEndMarker,
     renameSegment, exportAudioSegments,
@@ -22,6 +22,7 @@
   let shortcutsCollapsed = $state(false);
 
   onMount(() => {
+    loadShortcuts();
     document.addEventListener('keydown', handleKeydown);
     const media = window.matchMedia('(max-width: 900px)');
     const syncShortcutsLayout = () => {

--- a/src/tests/helpers/reset-state.ts
+++ b/src/tests/helpers/reset-state.ts
@@ -1,4 +1,5 @@
 import { appState } from '$lib/state.svelte';
+import { DEFAULT_SHORTCUTS } from '$lib/shortcuts';
 
 export function resetAppState() {
   appState.metadata         = null;
@@ -25,4 +26,5 @@ export function resetAppState() {
   appState.wavesurfer       = null;
   appState.zoomLevel        = 1;
   appState.waveformWrapEl   = null;
+  appState.shortcuts        = { ...DEFAULT_SHORTCUTS };
 }

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -150,7 +150,7 @@ describe('handleKeydown — markers', () => {
     expect(handler).toHaveBeenCalledWith('delete_marker', { id: 'm1' });
   });
 
-  it('Backspace deletes the selected marker', async () => {
+  it('Backspace also deletes the selected marker (default multi-key bind)', async () => {
     appState.markers = [{ id: 'm1', position: 1000, kind: 'start' }];
     appState.selectedMarkerId = 'm1';
     const handler = vi.fn(() => undefined);
@@ -410,15 +410,15 @@ describe('handleKeydown — zoom', () => {
     expect(appState.zoomLevel).toBe(1);
   });
 
-  it('+ key increments zoom level', () => {
+  it('= key increments zoom level', () => {
     appState.zoomLevel = 2;
-    handleKeydown(keyEvent('+'));
+    handleKeydown(keyEvent('='));
     expect(appState.zoomLevel).toBe(4);
   });
 
-  it('= key also increments zoom level (unshifted + key)', () => {
+  it('+ key also increments zoom level (default multi-key bind)', () => {
     appState.zoomLevel = 2;
-    handleKeydown(keyEvent('='));
+    handleKeydown(keyEvent('+'));
     expect(appState.zoomLevel).toBe(4);
   });
 
@@ -428,7 +428,16 @@ describe('handleKeydown — zoom', () => {
     expect(appState.zoomLevel).toBe(16);
   });
 
-  it('stepping through all levels with + reaches maximum', () => {
+  it('stepping through all levels with = reaches maximum', () => {
+    appState.zoomLevel = 1;
+    handleKeydown(keyEvent('='));
+    handleKeydown(keyEvent('='));
+    handleKeydown(keyEvent('='));
+    handleKeydown(keyEvent('='));
+    expect(appState.zoomLevel).toBe(16);
+  });
+
+  it('stepping through all levels with + also reaches maximum', () => {
     appState.zoomLevel = 1;
     handleKeydown(keyEvent('+'));
     handleKeydown(keyEvent('+'));
@@ -462,5 +471,53 @@ describe('handleKeydown — export', () => {
     handleKeydown(keyEvent('e', { metaKey: true }));
     await flush();
     expect(handler).toHaveBeenCalledWith('export_csv', expect.anything());
+  });
+});
+
+describe('handleKeydown — custom shortcuts config', () => {
+  it('respects a remapped togglePlay key', async () => {
+    appState.shortcuts = { ...appState.shortcuts, togglePlay: [{ key: 'p' }] };
+    appState.isPlaying = false;
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent('p'));
+    await flush();
+    expect(handler).toHaveBeenCalledWith('play', expect.anything());
+  });
+
+  it('default Space no longer triggers play after remapping', async () => {
+    appState.shortcuts = { ...appState.shortcuts, togglePlay: [{ key: 'p' }] };
+    appState.isPlaying = false;
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent(' '));
+    await flush();
+    expect(handler).not.toHaveBeenCalledWith('play', expect.anything());
+  });
+
+  it('supports multi-key binds — both keys trigger the action', async () => {
+    appState.shortcuts = { ...appState.shortcuts, togglePlay: [{ key: 'p' }, { key: 'q' }] };
+    appState.isPlaying = false;
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    handleKeydown(keyEvent('q'));
+    await flush();
+    expect(handler).toHaveBeenCalledWith('play', expect.anything());
+  });
+
+  it('cancelEdit respects custom key', () => {
+    appState.shortcuts = { ...appState.shortcuts, cancelEdit: [{ key: 'q' }] };
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    handleKeydown(keyEvent('q'));
+    expect(appState.editingMarkerId).toBeNull();
+  });
+
+  it('default Escape no longer cancels edit after remapping', () => {
+    appState.shortcuts = { ...appState.shortcuts, cancelEdit: [{ key: 'q' }] };
+    appState.editingMarkerId = 'm1';
+    appState.editingPositionMs = 5000;
+    handleKeydown(keyEvent('Escape'));
+    expect(appState.editingMarkerId).toBe('m1');
   });
 });

--- a/src/tests/unit/shortcuts.test.ts
+++ b/src/tests/unit/shortcuts.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { matchesShortcut, formatShortcutKey } from '$lib/shortcuts';
+import type { ShortcutKey } from '$lib/shortcuts';
+
+function keyEvent(key: string, extra: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...extra });
+}
+
+describe('matchesShortcut', () => {
+  it('matches a plain key', () => {
+    expect(matchesShortcut(keyEvent('s'), [{ key: 's' }])).toBe(true);
+  });
+
+  it('does not match a different key', () => {
+    expect(matchesShortcut(keyEvent('e'), [{ key: 's' }])).toBe(false);
+  });
+
+  it('matches case-insensitively for uppercase event', () => {
+    expect(matchesShortcut(keyEvent('S'), [{ key: 's' }])).toBe(true);
+  });
+
+  it('matches case-insensitively for uppercase config key', () => {
+    expect(matchesShortcut(keyEvent('s'), [{ key: 'S' }])).toBe(true);
+  });
+
+  it('matches when ctrl is required and ctrlKey is held', () => {
+    expect(matchesShortcut(keyEvent('e', { ctrlKey: true }), [{ key: 'e', ctrl: true }])).toBe(true);
+  });
+
+  it('matches ctrl shortcut when metaKey is held (cross-platform)', () => {
+    expect(matchesShortcut(keyEvent('e', { metaKey: true }), [{ key: 'e', ctrl: true }])).toBe(true);
+  });
+
+  it('does not match ctrl shortcut without modifier', () => {
+    expect(matchesShortcut(keyEvent('e'), [{ key: 'e', ctrl: true }])).toBe(false);
+  });
+
+  it('does not match plain key when ctrl is held but not required', () => {
+    expect(matchesShortcut(keyEvent('e', { ctrlKey: true }), [{ key: 'e' }])).toBe(false);
+  });
+
+  it('matches when shift is required and shiftKey is held', () => {
+    expect(matchesShortcut(keyEvent('a', { shiftKey: true }), [{ key: 'a', shift: true }])).toBe(true);
+  });
+
+  it('does not match shift shortcut without shiftKey', () => {
+    expect(matchesShortcut(keyEvent('a'), [{ key: 'a', shift: true }])).toBe(false);
+  });
+
+  it('matches alt shortcut when altKey is held', () => {
+    expect(matchesShortcut(keyEvent('z', { altKey: true }), [{ key: 'z', alt: true }])).toBe(true);
+  });
+
+  it('does not match alt shortcut without altKey', () => {
+    expect(matchesShortcut(keyEvent('z'), [{ key: 'z', alt: true }])).toBe(false);
+  });
+
+  it('matches space key', () => {
+    expect(matchesShortcut(keyEvent(' '), [{ key: ' ' }])).toBe(true);
+  });
+
+  it('matches arrow keys exactly', () => {
+    expect(matchesShortcut(keyEvent('ArrowRight'), [{ key: 'ArrowRight' }])).toBe(true);
+    expect(matchesShortcut(keyEvent('ArrowLeft'),  [{ key: 'ArrowLeft'  }])).toBe(true);
+  });
+
+  it('does not match wrong arrow direction', () => {
+    expect(matchesShortcut(keyEvent('ArrowRight'), [{ key: 'ArrowLeft' }])).toBe(false);
+  });
+
+  it('matches the first binding in a multi-key array', () => {
+    const keys: ShortcutKey[] = [{ key: 'Delete' }, { key: 'Backspace' }];
+    expect(matchesShortcut(keyEvent('Delete'), keys)).toBe(true);
+  });
+
+  it('matches the second binding in a multi-key array', () => {
+    const keys: ShortcutKey[] = [{ key: 'Delete' }, { key: 'Backspace' }];
+    expect(matchesShortcut(keyEvent('Backspace'), keys)).toBe(true);
+  });
+
+  it('does not match a key not in the array', () => {
+    const keys: ShortcutKey[] = [{ key: 'Delete' }, { key: 'Backspace' }];
+    expect(matchesShortcut(keyEvent('x'), keys)).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(matchesShortcut(keyEvent('s'), [])).toBe(false);
+  });
+});
+
+describe('formatShortcutKey', () => {
+  it('formats a plain letter', () => {
+    expect(formatShortcutKey({ key: 's' })).toBe('S');
+  });
+
+  it('formats space as "Space"', () => {
+    expect(formatShortcutKey({ key: ' ' })).toBe('Space');
+  });
+
+  it('formats arrow keys as symbols', () => {
+    expect(formatShortcutKey({ key: 'ArrowLeft'  })).toBe('←');
+    expect(formatShortcutKey({ key: 'ArrowRight' })).toBe('→');
+    expect(formatShortcutKey({ key: 'ArrowUp'    })).toBe('↑');
+    expect(formatShortcutKey({ key: 'ArrowDown'  })).toBe('↓');
+  });
+
+  it('formats Escape as "Esc"', () => {
+    expect(formatShortcutKey({ key: 'Escape' })).toBe('Esc');
+  });
+
+  it('formats Delete as "Del"', () => {
+    expect(formatShortcutKey({ key: 'Delete' })).toBe('Del');
+  });
+
+  it('prepends Ctrl+ for ctrl modifier', () => {
+    expect(formatShortcutKey({ key: 'e', ctrl: true })).toBe('Ctrl+E');
+  });
+
+  it('prepends Shift+ for shift modifier', () => {
+    expect(formatShortcutKey({ key: 'a', shift: true })).toBe('Shift+A');
+  });
+
+  it('prepends Alt+ for alt modifier', () => {
+    expect(formatShortcutKey({ key: 'z', alt: true })).toBe('Alt+Z');
+  });
+
+  it('stacks multiple modifiers in order', () => {
+    expect(formatShortcutKey({ key: 's', ctrl: true, shift: true })).toBe('Ctrl+Shift+S');
+  });
+
+  it('formats bracket keys as-is', () => {
+    expect(formatShortcutKey({ key: '[' })).toBe('[');
+    expect(formatShortcutKey({ key: ']' })).toBe(']');
+  });
+});


### PR DESCRIPTION
This pull request addresses #55. 

In this pull request an "edit mode" is added to the shortcuts section that allows the user to customize the shortcuts provided within the app. Users can add multiple key bindings to a singular shortcut and later reset to the defaults if needed. This will allow users with non-QWERTY keyboards to utilize the shortcut functionality within the app. 