### PR TITLE
Continuous Zoom

### DIFF
--- a/docs/developer-documentation/index.md
+++ b/docs/developer-documentation/index.md
@@ -75,7 +75,7 @@ The frontend lives in `src/`.
 - `src/lib/actions.ts` is the main frontend behavior layer. It handles polling playback position, requestAnimationFrame interpolation, keyboard shortcuts, seeking, file opening, marker operations, segment validation, CSV import, and export commands.
 - `src/lib/types.ts` defines frontend TypeScript interfaces that mirror serialized Rust data: file metadata, playback position, markers, marker kinds, and segments.
 - `src/lib/shortcuts.ts` defines available shortcut actions, default bindings, shortcut matching, and display formatting.
-- `src/lib/utils.ts` contains formatting and parsing helpers for timestamps, marker labels, playback speeds, and zoom levels.
+- `src/lib/utils.ts` contains formatting and parsing helpers for timestamps, marker labels, playback speeds, and zoom behavior.
 - `src/lib/validation.ts` maps backend validation error messages to affected marker IDs for UI highlighting.
 
 ### Frontend Tests
@@ -460,5 +460,3 @@ Use the Linux dependency list in `.github/workflows/ci.yml` and `.github/workflo
 - Keep generated files out of hand edits. Edit source files, then regenerate through normal build/test commands.
 - Update `README.md`, user docs, or developer docs whenever a user-visible workflow, install step, command, or supported file format changes.
 - When changing bundle behavior, test both `npm run tauri dev` and `npm run tauri build`.
-
-

--- a/docs/user-documentation/index.md
+++ b/docs/user-documentation/index.md
@@ -18,7 +18,7 @@ When the app is first opened the user is presented with a dialog that allows the
 
 ### Waveform Diagram
 
-The waveform diagram shows the user the waveform for their uploaded audio files. The user can zoom in on the waveform diagram using the shortcuts to place markers more precisely.
+The waveform diagram shows the user the waveform for their uploaded audio files. Users can zoom with `-` and `+` / `=`, or by scrolling or pinching over the waveform area, to place markers more precisely.
 
 Below the waveform diagram is a series of buttons for playing/pausing the audio, jumping forward/backward, and two toggles: loop and follow. The loop toggle, when enabled, will make the audio play on a loop. If the playhead reaches the end of the audio file it will automatically return to the start of the audio file and continue playing. The follow toggle forces the waveform diagram to move with the playhead (and vice versa) when the waveform is zoomed in. Both of these toggles default to being turned off. 
 

--- a/docs/user-documentation/shortcuts.md
+++ b/docs/user-documentation/shortcuts.md
@@ -26,8 +26,8 @@ The default shortcuts and keybindings provided within the app are as follows:
 | `3` | Set playback speed to 1× |
 | `4` | Set playback speed to 1.5× |
 | `5` | Set playback speed to 2× |
-| `-` | Zoom out |
-| `+` / `=` | Zoom in |
+| `-`, Pinch Apart, Scroll Up | Zoom out |
+| `+` / `=`, Pinch Together, Scroll Down | Zoom in |
 | `S` | Add start marker at current position |
 | `E` | Add end marker at current position |
 | `B` | Add start/end marker at current position |

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -2,9 +2,18 @@
   import { invoke, convertFileSrc } from '@tauri-apps/api/core';
   import WaveSurfer from 'wavesurfer.js';
   import { appState } from '$lib/state.svelte';
-  import { kindLabel, formatMs, ZOOM_LEVELS } from '$lib/utils';
+  import {
+    kindLabel,
+    formatMs,
+    formatMsDisplay,
+    ZOOM_DEFAULT,
+    maxZoomForDuration,
+    minZoomForDuration,
+    shouldHandleWheelZoom,
+    zoomFromWheelDelta,
+  } from '$lib/utils';
   import { validationProblemMarkerIds } from '$lib/validation';
-  import { moveEditingMarkerToMs } from '$lib/actions';
+  import { moveEditingMarkerToMs, setZoomLevel, zoomIn, zoomOut } from '$lib/actions';
 
   let waveformEl     = $state<HTMLDivElement | null>(null);
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
@@ -52,6 +61,12 @@
   }
 
   const ticks = $derived(computeTicks(appState.durationMs, appState.zoomLevel));
+  const minZoomForFile = $derived(minZoomForDuration(appState.durationMs));
+  const maxZoomForFile = $derived(maxZoomForDuration(appState.durationMs));
+  const visibleWindowMs = $derived(appState.zoomLevel > 0 && appState.durationMs > 0
+    ? appState.durationMs / appState.zoomLevel
+    : 0);
+  const zoomWindowLabel = $derived(visibleWindowMs > 0 ? formatMsDisplay(visibleWindowMs, visibleWindowMs) : '0.000');
 
   // Expose the wrap element so external code can scroll it if needed
   $effect(() => { appState.waveformWrapEl = waveformWrapEl; });
@@ -63,7 +78,10 @@
     if (!filePath || !waveformEl) return;
 
     // Reset zoom and scroll when a new file is loaded
-    appState.zoomLevel = 1;
+    appState.zoomLevel = Math.min(
+      Math.max(ZOOM_DEFAULT, minZoomForDuration(appState.durationMs)),
+      maxZoomForDuration(appState.durationMs),
+    );
     if (waveformWrapEl) waveformWrapEl.scrollLeft = 0;
 
     const ws = WaveSurfer.create({
@@ -106,16 +124,23 @@
     waveformWrapEl.scrollLeft = Math.max(0, pct * total - visible / 2);
   });
 
-  // ── Zoom controls ──────────────────────────────────────────────────────
-
-  function zoomIn() {
-    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
-    if (i < ZOOM_LEVELS.length - 1) appState.zoomLevel = ZOOM_LEVELS[i + 1];
-  }
-
-  function zoomOut() {
-    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
-    if (i > 0) appState.zoomLevel = ZOOM_LEVELS[i - 1];
+  // ── Zoom controls / interactions ───────────────────────────────────────
+  async function handleWheelZoom(e: WheelEvent) {
+    if (!waveformWrapEl || !appState.metadata || appState.durationMs <= 0) return;
+    if (!shouldHandleWheelZoom({
+      deltaX: e.deltaX,
+      deltaY: e.deltaY,
+      ctrlKey: e.ctrlKey,
+      metaKey: e.metaKey,
+    })) return;
+    e.preventDefault();
+    const nextZoom = zoomFromWheelDelta(
+      appState.zoomLevel,
+      e.deltaY,
+      appState.durationMs,
+      e.ctrlKey || e.metaKey
+    );
+    setZoomLevel(nextZoom);
   }
 
   // ── Waveform drag seeking ──────────────────────────────────────────────
@@ -202,14 +227,14 @@
   <button
     class="zoom-btn"
     onclick={zoomOut}
-    disabled={!appState.metadata || appState.zoomLevel <= 1}
+    disabled={!appState.metadata || appState.zoomLevel <= minZoomForFile}
     title="Zoom out"
   >−</button>
-  <span class="zoom-label">{appState.zoomLevel}x</span>
+  <span class="zoom-label">{zoomWindowLabel}</span>
   <button
     class="zoom-btn"
     onclick={zoomIn}
-    disabled={!appState.metadata || appState.zoomLevel >= 16}
+    disabled={!appState.metadata || appState.zoomLevel >= maxZoomForFile}
     title="Zoom in"
   >+</button>
 </div>
@@ -228,6 +253,7 @@
   onpointermove={handlePointerMove}
   onpointerup={handlePointerUp}
   onpointercancel={handlePointerUp}
+  onwheel={handleWheelZoom}
 >
   {#if appState.editingMarkerId}
     <div class="edit-mode-hint">Click to move marker · Enter to confirm · Esc to cancel</div>

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -17,6 +17,8 @@
 
   let waveformEl     = $state<HTMLDivElement | null>(null);
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
+  let waveformResizeQueued = false;
+  let lastWaveformWidth = 0;
   const validationProblemIds = $derived(validationProblemMarkerIds(appState.markers, appState.validationError));
 
   // ── Timeline tick helpers ──────────────────────────────────────────────
@@ -71,6 +73,29 @@
   // Expose the wrap element so external code can scroll it if needed
   $effect(() => { appState.waveformWrapEl = waveformWrapEl; });
 
+  function queueWaveformResize() {
+    if (waveformResizeQueued) return;
+    waveformResizeQueued = true;
+    requestAnimationFrame(() => {
+      waveformResizeQueued = false;
+      if (!appState.wavesurfer || !waveformEl || !appState.metadata) return;
+      const width = Math.round(waveformEl.clientWidth);
+      if (width > 0 && width !== lastWaveformWidth) {
+        lastWaveformWidth = width;
+        appState.wavesurfer.setOptions({ width });
+      }
+    });
+  }
+
+  // Keep the waveform canvas width in sync with zoom width changes so
+  // the WaveSurfer render does not lag behind the timeline/markers.
+  $effect(() => {
+    const zoomLevel = appState.zoomLevel;
+    const ws = appState.wavesurfer;
+    if (!ws || !waveformEl || !appState.metadata) return;
+    queueWaveformResize();
+  });
+
   // Initialize (or reinitialize) WaveSurfer whenever the loaded file changes.
   // The cleanup function runs on component destroy or before re-running.
   $effect(() => {
@@ -99,6 +124,8 @@
     });
     ws.load(convertFileSrc(filePath));
     appState.wavesurfer = ws;
+    lastWaveformWidth = 0;
+    queueWaveformResize();
 
     const resizeObserver = new ResizeObserver(([entry]) => {
       const height = Math.round(entry.contentRect.height) - TIMELINE_HEIGHT;
@@ -141,6 +168,14 @@
       e.ctrlKey || e.metaKey
     );
     setZoomLevel(nextZoom);
+  }
+
+  function handleZoomInClick() {
+    zoomIn();
+  }
+
+  function handleZoomOutClick() {
+    zoomOut();
   }
 
   // ── Waveform drag seeking ──────────────────────────────────────────────
@@ -226,14 +261,14 @@
 <div class="zoom-controls">
   <button
     class="zoom-btn"
-    onclick={zoomOut}
+    onclick={handleZoomOutClick}
     disabled={!appState.metadata || appState.zoomLevel <= minZoomForFile}
     title="Zoom out"
   >−</button>
   <span class="zoom-label">{zoomWindowLabel}</span>
   <button
     class="zoom-btn"
-    onclick={zoomIn}
+    onclick={handleZoomInClick}
     disabled={!appState.metadata || appState.zoomLevel >= maxZoomForFile}
     title="Zoom in"
   >+</button>

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { invoke, convertFileSrc } from '@tauri-apps/api/core';
   import WaveSurfer from 'wavesurfer.js';
   import { appState } from '$lib/state.svelte';
@@ -19,6 +20,20 @@
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
   let waveformResizeQueued = false;
   let lastWaveformWidth = 0;
+  // The zoom level that WaveSurfer's canvas was last rendered at. While the
+  // user is mid-gesture (wheel/pinch zoom), we defer the (expensive) WaveSurfer
+  // re-render and instead CSS-scale the rendered canvas to match the current
+  // zoom — this keeps zooming smooth even at high zoom levels.
+  let lastRenderedZoom = $state(1);
+  let pendingZoomRenderTimer: ReturnType<typeof setTimeout> | null = null;
+  // While true, queueWaveformResize() will defer the WaveSurfer width update.
+  // CSS transform on .waveform-inner provides the visual zoom in the meantime.
+  let zoomRenderDeferred = false;
+  // ms of inactivity after the last zoom change before we trigger a re-render.
+  const ZOOM_RENDER_DEBOUNCE_MS = 120;
+  // If the displayed zoom drifts too far from the rendered zoom, force a
+  // re-render even mid-gesture so the waveform doesn't get unusably blurry.
+  const ZOOM_RENDER_MAX_RATIO = 2.5;
   const validationProblemIds = $derived(validationProblemMarkerIds(appState.markers, appState.validationError));
 
   // ── Timeline tick helpers ──────────────────────────────────────────────
@@ -79,22 +94,74 @@
     requestAnimationFrame(() => {
       waveformResizeQueued = false;
       if (!appState.wavesurfer || !waveformEl || !appState.metadata) return;
+      // While a continuous zoom gesture is in flight, skip the expensive
+      // WaveSurfer re-render — the CSS transform on .waveform-inner handles
+      // the visual update. We'll re-render once the gesture settles.
+      if (zoomRenderDeferred) return;
       const width = Math.round(waveformEl.clientWidth);
       if (width > 0 && width !== lastWaveformWidth) {
         lastWaveformWidth = width;
         appState.wavesurfer.setOptions({ width });
+        lastRenderedZoom = appState.zoomLevel;
       }
     });
   }
 
+  // Force a WaveSurfer re-render at the current zoom level, regardless of
+  // whether a zoom gesture is still in flight.
+  function flushWaveformResize() {
+    if (pendingZoomRenderTimer) {
+      clearTimeout(pendingZoomRenderTimer);
+      pendingZoomRenderTimer = null;
+    }
+    zoomRenderDeferred = false;
+    if (!appState.wavesurfer || !waveformEl || !appState.metadata) return;
+    const width = Math.round(waveformEl.clientWidth);
+    if (width > 0 && width !== lastWaveformWidth) {
+      lastWaveformWidth = width;
+      appState.wavesurfer.setOptions({ width });
+    }
+    lastRenderedZoom = appState.zoomLevel;
+  }
+
+  function scheduleDeferredZoomRender() {
+    if (pendingZoomRenderTimer) clearTimeout(pendingZoomRenderTimer);
+    pendingZoomRenderTimer = setTimeout(() => {
+      pendingZoomRenderTimer = null;
+      flushWaveformResize();
+    }, ZOOM_RENDER_DEBOUNCE_MS);
+  }
+
   // Keep the waveform canvas width in sync with zoom width changes so
   // the WaveSurfer render does not lag behind the timeline/markers.
+  // During continuous zoom gestures we debounce the (expensive) WaveSurfer
+  // re-render; the canvas is CSS-scaled in the meantime via the
+  // `--waveform-zoom-scale` custom property.
   $effect(() => {
     const zoomLevel = appState.zoomLevel;
     const ws = appState.wavesurfer;
     if (!ws || !waveformEl || !appState.metadata) return;
-    queueWaveformResize();
+    if (!zoomRenderDeferred) {
+      // Not currently in a deferred-render state. Re-render immediately.
+      queueWaveformResize();
+      return;
+    }
+    // Mid-gesture. If zoom drifts too far from the rendered baseline, the
+    // CSS-scaled waveform becomes unacceptably blurry/squashed — flush early.
+    const ratio = zoomLevel / lastRenderedZoom;
+    if (ratio >= ZOOM_RENDER_MAX_RATIO || ratio <= 1 / ZOOM_RENDER_MAX_RATIO) {
+      flushWaveformResize();
+    } else {
+      scheduleDeferredZoomRender();
+    }
   });
+
+  // CSS scale factor applied to the WaveSurfer canvas while the renderer's
+  // baseline zoom is stale. This makes continuous zoom gestures feel
+  // instantaneous without forcing a redraw on every event.
+  const waveformZoomScale = $derived(
+    lastRenderedZoom > 0 ? appState.zoomLevel / lastRenderedZoom : 1,
+  );
 
   // Initialize (or reinitialize) WaveSurfer whenever the loaded file changes.
   // The cleanup function runs on component destroy or before re-running.
@@ -125,6 +192,15 @@
     ws.load(convertFileSrc(filePath));
     appState.wavesurfer = ws;
     lastWaveformWidth = 0;
+    // Read zoom via untrack so this $effect doesn't depend on zoomLevel —
+    // otherwise every zoom change would tear down and recreate WaveSurfer
+    // and reset the zoom back to default.
+    lastRenderedZoom = untrack(() => appState.zoomLevel);
+    zoomRenderDeferred = false;
+    if (pendingZoomRenderTimer) {
+      clearTimeout(pendingZoomRenderTimer);
+      pendingZoomRenderTimer = null;
+    }
     queueWaveformResize();
 
     const resizeObserver = new ResizeObserver(([entry]) => {
@@ -135,6 +211,10 @@
 
     return () => {
       resizeObserver.disconnect();
+      if (pendingZoomRenderTimer) {
+        clearTimeout(pendingZoomRenderTimer);
+        pendingZoomRenderTimer = null;
+      }
       ws.destroy();
       appState.wavesurfer = null;
     };
@@ -161,6 +241,9 @@
       metaKey: e.metaKey,
     })) return;
     e.preventDefault();
+    // Mark this as a continuous gesture so the zoom $effect debounces the
+    // expensive WaveSurfer re-render and just CSS-scales mid-flight.
+    zoomRenderDeferred = true;
     const nextZoom = zoomFromWheelDelta(
       appState.zoomLevel,
       e.deltaY,
@@ -171,11 +254,16 @@
   }
 
   function handleZoomInClick() {
+    // Discrete zoom: render immediately rather than waiting for a debounce.
+    zoomRenderDeferred = false;
     zoomIn();
+    flushWaveformResize();
   }
 
   function handleZoomOutClick() {
+    zoomRenderDeferred = false;
     zoomOut();
+    flushWaveformResize();
   }
 
   // ── Waveform drag seeking ──────────────────────────────────────────────
@@ -294,7 +382,12 @@
     <div class="edit-mode-hint">Click to move marker · Enter to confirm · Esc to cancel</div>
   {/if}
   <div class="waveform-scroll" style="width: {appState.zoomLevel * 100}%">
-    <div class="waveform-inner" bind:this={waveformEl}></div>
+    <div
+      class="waveform-inner"
+      class:waveform-inner-scaled={waveformZoomScale !== 1}
+      style:--waveform-zoom-scale={waveformZoomScale}
+      bind:this={waveformEl}
+    ></div>
     <!-- Marker overlays — left: pct% is relative to waveform-scroll, same width as the waveform -->
     {#each appState.markers as m (m.id)}
       {@const isEditing = appState.editingMarkerId === m.id}
@@ -425,6 +518,16 @@
     width: 100%;
     flex: 1;
     min-height: 0;
+  }
+
+  /* During a continuous zoom gesture we defer the (expensive) WaveSurfer
+     re-render and instead CSS-scale the existing canvas so the waveform stays
+     aligned with the timeline & markers. The transform is horizontal-only with
+     a left origin so playhead/marker positions remain meaningful. */
+  .waveform-inner-scaled {
+    transform: scaleX(var(--waveform-zoom-scale, 1));
+    transform-origin: 0 0;
+    will-change: transform;
   }
 
   .timeline-ruler {

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -265,7 +265,7 @@
     disabled={!appState.metadata || appState.zoomLevel <= minZoomForFile}
     title="Zoom out"
   >−</button>
-  <span class="zoom-label">{zoomWindowLabel}</span>
+  <span class="zoom-label">{zoomWindowLabel}s</span>
   <button
     class="zoom-btn"
     onclick={handleZoomInClick}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,14 @@
 import { invoke } from '@tauri-apps/api/core';
 import { appState } from './state.svelte';
-import { SPEEDS, ZOOM_LEVELS } from './utils';
+import {
+  SPEEDS,
+  clampZoom,
+  computeZoomedScrollLeftCentered,
+  maxZoomForDuration,
+  minZoomForDuration,
+  zoomInLevel,
+  zoomOutLevel,
+} from './utils';
 import { DEFAULT_SHORTCUTS, matchesShortcut } from './shortcuts';
 import type { ShortcutConfig } from './shortcuts';
 import type { FileMetadata, PlaybackPosition, Marker, Segment, MarkerKind } from './types';
@@ -133,13 +141,43 @@ export function handleKeydown(e: KeyboardEvent) {
     e.preventDefault(); setSpeed(SPEEDS[4]);
   } else if (matchesShortcut(e, s.zoomOut)) {
     e.preventDefault();
-    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
-    if (i > 0) appState.zoomLevel = ZOOM_LEVELS[i - 1];
+    zoomOut();
   } else if (matchesShortcut(e, s.zoomIn)) {
     e.preventDefault();
-    const i = ZOOM_LEVELS.indexOf(appState.zoomLevel);
-    if (i < ZOOM_LEVELS.length - 1) appState.zoomLevel = ZOOM_LEVELS[i + 1];
+    zoomIn();
   }
+}
+
+export function setZoomLevel(level: number): number {
+  const prev = appState.zoomLevel;
+  const duration = appState.durationMs;
+  const minZoom = minZoomForDuration(duration);
+  const maxZoom = maxZoomForDuration(duration);
+  const next = Math.min(Math.max(clampZoom(level), minZoom), maxZoom);
+  appState.zoomLevel = next;
+  if (appState.waveformWrapEl && next !== prev) {
+    const wrap = appState.waveformWrapEl;
+    const previousScrollLeft = wrap.scrollLeft;
+    const viewportWidth = wrap.clientWidth;
+    requestAnimationFrame(() => {
+      if (!appState.waveformWrapEl) return;
+      appState.waveformWrapEl.scrollLeft = computeZoomedScrollLeftCentered({
+        scrollLeft: previousScrollLeft,
+        viewportWidth,
+        prevZoom: prev,
+        nextZoom: next,
+      });
+    });
+  }
+  return next;
+}
+
+export function zoomIn(step = 1): number {
+  return setZoomLevel(zoomInLevel(appState.zoomLevel, appState.durationMs, step));
+}
+
+export function zoomOut(step = 1): number {
+  return setZoomLevel(zoomOutLevel(appState.zoomLevel, appState.durationMs, step));
 }
 
 // ── Seeking ───────────────────────────────────────────────────────────────

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -36,7 +36,7 @@ class AppState {
   wavesurfer: WaveSurfer | null = null;
 
   // ── Zoom (reactive) + scroll container ref (non-reactive) ─────────────
-  zoomLevel = $state(1);  // multiplier: 1 | 2 | 4 | 8 | 16
+  zoomLevel = $state(1);  // 1 = 100% (waveform fills viewport width)
   waveformWrapEl: HTMLDivElement | null = null;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,7 +48,7 @@ export const ZOOM_HARD_LIMIT = 1_000;
 export const ZOOM_MAX_WINDOW_MS = 256 * 60_000;
 export const ZOOM_MIN_WINDOW_MS = 7_500;
 export const ZOOM_WHEEL_SENSITIVITY = 1 / 480;
-export const ZOOM_PINCH_SENSITIVITY = 1 / 700;
+export const ZOOM_PINCH_SENSITIVITY = 3 / 700;
 
 function roundZoom(level: number): number {
   return Number(level.toFixed(6));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,7 +41,82 @@ export function kindLabel(kind: MarkerKind): string {
 }
 
 export const SPEEDS = [0.5, 0.75, 1, 1.5, 2];
-export const ZOOM_LEVELS = [1, 2, 4, 8, 16];
+export const ZOOM_DEFAULT = 1;
+export const ZOOM_MIN = 0.25;
+export const ZOOM_STEP_FACTOR = 2;
+export const ZOOM_HARD_LIMIT = 1_000;
+export const ZOOM_MAX_WINDOW_MS = 256 * 60_000;
+export const ZOOM_MIN_WINDOW_MS = 7_500;
+export const ZOOM_WHEEL_SENSITIVITY = 1 / 480;
+export const ZOOM_PINCH_SENSITIVITY = 1 / 700;
+
+function roundZoom(level: number): number {
+  return Number(level.toFixed(6));
+}
+
+export function clampZoomMin(level: number): number {
+  return roundZoom(Math.max(level, ZOOM_MIN));
+}
+
+export function clampZoom(level: number): number {
+  return roundZoom(Math.min(Math.max(level, ZOOM_MIN), ZOOM_HARD_LIMIT));
+}
+
+export function maxZoomForDuration(durationMs: number): number {
+  if (durationMs <= 0) return ZOOM_MIN;
+  const maxFromMinWindow = clampZoom(Math.max(ZOOM_MIN, durationMs / ZOOM_MIN_WINDOW_MS));
+  return Math.max(maxFromMinWindow, minZoomForDuration(durationMs));
+}
+
+export function minZoomForDuration(durationMs: number): number {
+  if (durationMs <= 0) return ZOOM_DEFAULT;
+  return ZOOM_DEFAULT;
+}
+
+function applyZoomBoundaries(level: number, durationMs: number): number {
+  const minZoom = minZoomForDuration(durationMs);
+  const maxZoom = maxZoomForDuration(durationMs);
+  return roundZoom(Math.min(Math.max(level, minZoom), maxZoom));
+}
+
+export function zoomInLevel(level: number, durationMs: number, step = 1): number {
+  return applyZoomBoundaries(level * ZOOM_STEP_FACTOR ** Math.max(step, 0), durationMs);
+}
+
+export function zoomOutLevel(level: number, durationMs: number, step = 1): number {
+  return applyZoomBoundaries(level / ZOOM_STEP_FACTOR ** Math.max(step, 0), durationMs);
+}
+
+export interface WheelZoomInput {
+  deltaX: number;
+  deltaY: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+export function shouldHandleWheelZoom(input: WheelZoomInput): boolean {
+  if (input.ctrlKey || input.metaKey) return input.deltaY !== 0;
+  return Math.abs(input.deltaY) > Math.abs(input.deltaX);
+}
+
+export function zoomFromWheelDelta(level: number, deltaY: number, durationMs: number, isPinch: boolean): number {
+  const sensitivity = isPinch ? ZOOM_PINCH_SENSITIVITY : ZOOM_WHEEL_SENSITIVITY;
+  const effectiveDelta = isPinch ? -deltaY : deltaY;
+  const factor = 2 ** (effectiveDelta * sensitivity);
+  return applyZoomBoundaries(level * factor, durationMs);
+}
+
+export function computeZoomedScrollLeftCentered(params: {
+  scrollLeft: number;
+  viewportWidth: number;
+  prevZoom: number;
+  nextZoom: number;
+}): number {
+  const { scrollLeft, viewportWidth, prevZoom, nextZoom } = params;
+  const ratio = nextZoom / prevZoom;
+  const centerPx = scrollLeft + viewportWidth / 2;
+  return Math.max(0, centerPx * ratio - viewportWidth / 2);
+}
 
 // Parses a flexible time string back to milliseconds. Accepted formats:
 //   "5"          → 5 seconds

--- a/src/tests/unit/actions.keyboard.test.ts
+++ b/src/tests/unit/actions.keyboard.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import { appState } from '$lib/state.svelte';
 import { handleKeydown } from '$lib/actions';
-import { SPEEDS } from '$lib/utils';
+import { SPEEDS, maxZoomForDuration, minZoomForDuration } from '$lib/utils';
 import { resetAppState } from '../helpers/reset-state';
 import type { FileMetadata } from '$lib/types';
 
@@ -31,6 +31,7 @@ beforeEach(() => {
   resetAppState();
   // Most keyboard tests require a file to be loaded
   appState.metadata = fakeMeta;
+  appState.durationMs = fakeMeta.durationMs;
 });
 
 describe('handleKeydown — guards', () => {
@@ -398,61 +399,70 @@ describe('handleKeydown — edit mode', () => {
 });
 
 describe('handleKeydown — zoom', () => {
-  it('- key decrements zoom level', () => {
-    appState.zoomLevel = 4;
-    handleKeydown(keyEvent('-'));
-    expect(appState.zoomLevel).toBe(2);
-  });
-
-  it('- key does nothing when already at minimum zoom (1)', () => {
-    appState.zoomLevel = 1;
-    handleKeydown(keyEvent('-'));
-    expect(appState.zoomLevel).toBe(1);
-  });
-
-  it('= key increments zoom level', () => {
+  it('- key decrements zoom level continuously', () => {
     appState.zoomLevel = 2;
+    handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBeLessThan(2);
+  });
+
+  it('- key does nothing when already at minimum zoom', () => {
+    appState.durationMs = 60_000;
+    appState.zoomLevel = minZoomForDuration(appState.durationMs);
+    handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBe(minZoomForDuration(appState.durationMs));
+  });
+
+  it('= key increments zoom level continuously', () => {
+    appState.zoomLevel = 1;
     handleKeydown(keyEvent('='));
-    expect(appState.zoomLevel).toBe(4);
+    expect(appState.zoomLevel).toBeGreaterThan(1);
   });
 
   it('+ key also increments zoom level (default multi-key bind)', () => {
-    appState.zoomLevel = 2;
-    handleKeydown(keyEvent('+'));
-    expect(appState.zoomLevel).toBe(4);
-  });
-
-  it('+ key does nothing when already at maximum zoom (16)', () => {
-    appState.zoomLevel = 16;
-    handleKeydown(keyEvent('+'));
-    expect(appState.zoomLevel).toBe(16);
-  });
-
-  it('stepping through all levels with = reaches maximum', () => {
-    appState.zoomLevel = 1;
-    handleKeydown(keyEvent('='));
-    handleKeydown(keyEvent('='));
-    handleKeydown(keyEvent('='));
-    handleKeydown(keyEvent('='));
-    expect(appState.zoomLevel).toBe(16);
-  });
-
-  it('stepping through all levels with + also reaches maximum', () => {
     appState.zoomLevel = 1;
     handleKeydown(keyEvent('+'));
-    handleKeydown(keyEvent('+'));
-    handleKeydown(keyEvent('+'));
-    handleKeydown(keyEvent('+'));
-    expect(appState.zoomLevel).toBe(16);
+    expect(appState.zoomLevel).toBeGreaterThan(1);
   });
 
-  it('stepping back through all levels with - reaches minimum', () => {
-    appState.zoomLevel = 16;
+  it('repeated + key presses keep increasing zoom without low fixed cap', () => {
+    appState.zoomLevel = 1;
+    const start = appState.zoomLevel;
+    for (let i = 0; i < 20; i++) handleKeydown(keyEvent('+'));
+    expect(appState.zoomLevel).toBeGreaterThan(start);
+  });
+
+  it('repeated = key presses keep increasing zoom without low fixed cap', () => {
+    appState.zoomLevel = 1;
+    const start = appState.zoomLevel;
+    for (let i = 0; i < 20; i++) handleKeydown(keyEvent('='));
+    expect(appState.zoomLevel).toBeGreaterThan(start);
+  });
+
+  it('stepping back with - eventually reaches the minimum zoom', () => {
+    appState.zoomLevel = 1;
+    appState.durationMs = 8 * 3_600_000;
+    for (let i = 0; i < 20; i++) handleKeydown(keyEvent('-'));
+    expect(appState.zoomLevel).toBe(minZoomForDuration(appState.durationMs));
+  });
+
+  it('zoom in then zoom out trends back toward the starting level', () => {
+    appState.zoomLevel = 1;
+    handleKeydown(keyEvent('+'));
+    const zoomed = appState.zoomLevel;
     handleKeydown(keyEvent('-'));
-    handleKeydown(keyEvent('-'));
-    handleKeydown(keyEvent('-'));
-    handleKeydown(keyEvent('-'));
-    expect(appState.zoomLevel).toBe(1);
+    expect(zoomed).toBeGreaterThan(1);
+    expect(appState.zoomLevel).toBeLessThanOrEqual(1);
+  });
+
+  it('zoom-in is clamped by duration-aware max zoom', () => {
+    appState.durationMs = 3_600_000;
+    appState.zoomLevel = maxZoomForDuration(appState.durationMs);
+    handleKeydown(keyEvent('+'));
+    expect(appState.zoomLevel).toBe(maxZoomForDuration(appState.durationMs));
+  });
+
+  it('a longer file allows a higher max zoom than a short file', () => {
+    expect(maxZoomForDuration(6 * 3_600_000)).toBeGreaterThan(maxZoomForDuration(60_000));
   });
 });
 

--- a/src/tests/unit/utils.test.ts
+++ b/src/tests/unit/utils.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from 'vitest';
-import { formatMs, formatMsDisplay, kindLabel, SPEEDS, ZOOM_LEVELS, parseTimeMs } from '$lib/utils';
+import {
+  formatMs,
+  formatMsDisplay,
+  kindLabel,
+  SPEEDS,
+  parseTimeMs,
+  ZOOM_DEFAULT,
+  ZOOM_MIN,
+  ZOOM_STEP_FACTOR,
+  ZOOM_PINCH_SENSITIVITY,
+  ZOOM_WHEEL_SENSITIVITY,
+  ZOOM_MIN_WINDOW_MS,
+  ZOOM_MAX_WINDOW_MS,
+  clampZoomMin,
+  maxZoomForDuration,
+  minZoomForDuration,
+  zoomInLevel,
+  zoomOutLevel,
+  shouldHandleWheelZoom,
+  zoomFromWheelDelta,
+  computeZoomedScrollLeftCentered,
+} from '$lib/utils';
 
 describe('formatMs', () => {
   it('formats zero as 00:00:00.000', () => {
@@ -129,30 +150,99 @@ describe('parseTimeMs', () => {
   });
 });
 
-describe('ZOOM_LEVELS', () => {
-  it('starts at 1 (no zoom)', () => {
-    expect(ZOOM_LEVELS[0]).toBe(1);
+describe('zoom helpers', () => {
+  it('uses 1.0 for default zoom (100%)', () => {
+    expect(ZOOM_DEFAULT).toBe(1);
   });
 
-  it('ends at 16 (maximum zoom)', () => {
-    expect(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]).toBe(16);
+  it('uses a minimum zoom less than default', () => {
+    expect(ZOOM_MIN).toBeLessThan(ZOOM_DEFAULT);
   });
 
-  it('has at least 3 steps', () => {
-    expect(ZOOM_LEVELS.length).toBeGreaterThanOrEqual(3);
+  it('uses a zoom-in step factor greater than 1', () => {
+    expect(ZOOM_STEP_FACTOR).toBeGreaterThan(1);
   });
 
-  it('is sorted in strictly ascending order', () => {
-    for (let i = 1; i < ZOOM_LEVELS.length; i++) {
-      expect(ZOOM_LEVELS[i]).toBeGreaterThan(ZOOM_LEVELS[i - 1]);
-    }
+  it('clampZoomMin enforces the minimum zoom', () => {
+    expect(clampZoomMin(0.001)).toBe(ZOOM_MIN);
   });
 
-  it('contains only positive integers', () => {
-    for (const level of ZOOM_LEVELS) {
-      expect(level).toBeGreaterThan(0);
-      expect(Number.isInteger(level)).toBe(true);
-    }
+  it('exposes a duration-aware min zoom window cap', () => {
+    expect(ZOOM_MAX_WINDOW_MS).toBeGreaterThan(ZOOM_MIN_WINDOW_MS);
+  });
+
+  it('max zoom scales up with longer files', () => {
+    expect(maxZoomForDuration(3_600_000)).toBeGreaterThan(maxZoomForDuration(60_000));
+  });
+
+  it('min zoom keeps 100% as the zoom-out floor', () => {
+    expect(minZoomForDuration(600_000)).toBe(1);
+    expect(minZoomForDuration(8 * 3_600_000)).toBe(1);
+  });
+
+  it('zoomInLevel doubles at each step by default', () => {
+    expect(zoomInLevel(1, 60_000)).toBeCloseTo(2, 6);
+  });
+
+  it('zoomOutLevel halves until duration-aware minimum is reached', () => {
+    const duration = 8 * 3_600_000;
+    expect(zoomOutLevel(1, duration)).toBe(minZoomForDuration(duration));
+  });
+
+  it('zoomOutLevel never drops below duration-aware min zoom', () => {
+    expect(zoomOutLevel(0.2, 60_000)).toBe(minZoomForDuration(60_000));
+  });
+});
+
+describe('wheel zoom helpers', () => {
+  it('handles pinch-like wheel when ctrl is pressed', () => {
+    expect(shouldHandleWheelZoom({ deltaX: 20, deltaY: 0.5, ctrlKey: true, metaKey: false })).toBe(true);
+  });
+
+  it('handles pinch-like wheel when meta is pressed', () => {
+    expect(shouldHandleWheelZoom({ deltaX: 20, deltaY: 0.5, ctrlKey: false, metaKey: true })).toBe(true);
+  });
+
+  it('ignores mostly horizontal wheel motion without pinch modifiers', () => {
+    expect(shouldHandleWheelZoom({ deltaX: 25, deltaY: 10, ctrlKey: false, metaKey: false })).toBe(false);
+  });
+
+  it('handles mostly vertical wheel motion without pinch modifiers', () => {
+    expect(shouldHandleWheelZoom({ deltaX: 5, deltaY: 30, ctrlKey: false, metaKey: false })).toBe(true);
+  });
+
+  it('uses slower pinch sensitivity than wheel sensitivity', () => {
+    expect(ZOOM_PINCH_SENSITIVITY).toBeLessThan(ZOOM_WHEEL_SENSITIVITY);
+  });
+
+  it('pinch delta changes zoom less than regular wheel delta', () => {
+    const base = 10;
+    const wheel = zoomFromWheelDelta(base, -120, 3_600_000, false);
+    const pinch = zoomFromWheelDelta(base, -120, 3_600_000, true);
+    // Both should zoom out for negative deltas, but pinch should be gentler.
+    expect(wheel).toBeLessThan(pinch);
+  });
+
+  it('positive delta zooms in and negative delta zooms out', () => {
+    const base = 4;
+    expect(zoomFromWheelDelta(base, 120, 3_600_000, false)).toBeGreaterThan(base);
+    expect(zoomFromWheelDelta(base, -120, 3_600_000, false)).toBeLessThan(base);
+  });
+
+  it('pinch uses opposite delta sign from wheel direction', () => {
+    const base = 4;
+    expect(zoomFromWheelDelta(base, 120, 3_600_000, true)).toBeLessThan(base);
+    expect(zoomFromWheelDelta(base, -120, 3_600_000, true)).toBeGreaterThan(base);
+  });
+
+  it('preserves center focus when computing scroll left after zoom', () => {
+    const nextScrollLeft = computeZoomedScrollLeftCentered({
+      scrollLeft: 100,
+      viewportWidth: 200,
+      prevZoom: 1,
+      nextZoom: 2,
+    });
+    expect(nextScrollLeft).toBe(300);
   });
 });
 

--- a/src/tests/unit/utils.test.ts
+++ b/src/tests/unit/utils.test.ts
@@ -211,8 +211,8 @@ describe('wheel zoom helpers', () => {
     expect(shouldHandleWheelZoom({ deltaX: 5, deltaY: 30, ctrlKey: false, metaKey: false })).toBe(true);
   });
 
-  it('uses slower pinch sensitivity than wheel sensitivity', () => {
-    expect(ZOOM_PINCH_SENSITIVITY).toBeLessThan(ZOOM_WHEEL_SENSITIVITY);
+  it('uses higher pinch sensitivity than wheel sensitivity', () => {
+    expect(ZOOM_PINCH_SENSITIVITY).toBeGreaterThan(ZOOM_WHEEL_SENSITIVITY);
   });
 
   it('pinch delta changes zoom less than regular wheel delta', () => {


### PR DESCRIPTION
Implements continuous zoom in-line with John's requirements. Zoom may be accomplished with +/- buttons, scroll, or pinch gestures (trackpad only).

"Zoom needs to be rethought. input files are likely to range from a few minutes to several hours. On a very long file 16X is still too low a temporal resolution to be useful. Probably having the maximum zoom show somewhere on the order of 7.5 - 15 seconds full scale (the width of the window) This would be 1/8 to 1/4 of a minute and should allow seeing differences of 1/10 of a second or so on the screen. this can go up in powers of two ad the mafnification decreases. e.g. 7.5.sec, 15 sec, 30 sec, 1 min, 2min, 4 min, etc. The upper bound should be set by the length of the file or, perhaps 256 minutes (~4.2 Hours)."

"Zoom should probably preserve the time at the center of the screen so that ckicking on a marker dot and zooming would expand the view on either side of the marker. This is useful because the user will probably be editing in the neighborhood of the marker,moving it slightly."