### PR TITLE
Prevent Highlighting + Other UI Tweaks

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -29,7 +29,7 @@
   <div class="header-left">
     <h1 class="app-title">Audio Ninja</h1>
     <p class="app-sub">
-      <span class="file-name" title={appState.metadata?.fileName}>{appState.metadata?.fileName}</span>
+      <span class="file-name copyable-text" title={appState.metadata?.fileName}>{appState.metadata?.fileName}</span>
       <span class="file-format">{fileFormat}</span>
     </p>
   </div>

--- a/src/components/MarkerPanel.svelte
+++ b/src/components/MarkerPanel.svelte
@@ -67,6 +67,7 @@
       {#each [...appState.markers].sort((a, b) => b.position - a.position) as m (m.id)}
         <div
           class="marker-row"
+          class:marker-row-has-split={m.kind === 'startEnd'}
           class:marker-row-selected={appState.selectedMarkerId === m.id}
           class:marker-row-editing={appState.editingMarkerId === m.id}
           class:marker-row-validation-error={validationProblemIds.has(m.id)}
@@ -121,7 +122,7 @@
               }}
             />
           {:else}
-            <span class="marker-time">{formatMs(m.position)}</span>
+            <span class="marker-time copyable-text">{formatMs(m.position)}</span>
           {/if}
           <select
             class="kind-select"
@@ -266,12 +267,11 @@
 
   .marker-row {
     display: grid;
-    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px 26px 26px;
+    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px minmax(0, 8px) 26px;
     align-items: center;
     column-gap: 8px;
     padding: 7px 14px;
     width: 100%;
-    min-width: max-content;
     min-height: 41px;
     cursor: pointer;
     border-bottom: 1px solid #161b22;
@@ -279,6 +279,10 @@
   }
 
   .marker-row:hover { background: #161b22; }
+
+  .marker-row.marker-row-has-split {
+    grid-template-columns: 8px minmax(86px, 1fr) minmax(64px, 88px) 26px 26px 26px;
+  }
 
   .marker-row-selected { background: #1a2640 !important; }
 
@@ -396,15 +400,19 @@
   .split-btn:hover { color: #facc15; border-color: #facc15; background: #1e1c0a; }
 
   .split-placeholder {
-    width: 26px;
+    width: 100%;
     height: 26px;
     flex-shrink: 0;
   }
 
   @media (max-width: 650px) {
     .marker-row {
-      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px 26px 26px;
+      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px minmax(0, 8px) 26px;
       column-gap: 6px;
+    }
+
+    .marker-row.marker-row-has-split {
+      grid-template-columns: 8px minmax(82px, 1fr) minmax(48px, 56px) 26px 26px 26px;
     }
 
     .kind-select {

--- a/src/components/PlaybackControls.svelte
+++ b/src/components/PlaybackControls.svelte
@@ -62,7 +62,7 @@
       </button>
     </div>
 
-    <span class="time-display">
+    <span class="time-display copyable-text">
       {formatMsDisplay(appState.positionMs, appState.durationMs)} / {formatMsDisplay(appState.durationMs, appState.durationMs)}
     </span>
   </div>

--- a/src/components/SegmentPanel.svelte
+++ b/src/components/SegmentPanel.svelte
@@ -28,9 +28,9 @@
         <div class="segment-row">
           <span class="seg-index">{String(i + 1).padStart(3, '0')}</span>
           <div class="seg-times">
-            <span class="seg-start">{formatMs(seg.startMs)}</span>
+            <span class="seg-start copyable-text">{formatMs(seg.startMs)}</span>
             <span class="seg-arrow">→</span>
-            <span class="seg-end">{formatMs(seg.endMs)}</span>
+            <span class="seg-end copyable-text">{formatMs(seg.endMs)}</span>
           </div>
           <div class="seg-title-wrap">
             <input

--- a/src/components/WelcomeScreen.svelte
+++ b/src/components/WelcomeScreen.svelte
@@ -6,7 +6,7 @@
 
 <div class="welcome">
   <div class="brand">
-    <span class="brand-name">Media Segment Marker</span>
+    <span class="brand-name">Audio Ninja</span>
     <span class="brand-sub">Precision audio/video segmentation tool</span>
   </div>
   <div class="upload-card">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,6 +95,20 @@
     line-height: 1.4;
     overflow: hidden;
     height: 100vh;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  :global(input),
+  :global(textarea),
+  :global([contenteditable='true']) {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
+  :global(.copyable-text) {
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .app {


### PR DESCRIPTION
- Prevent highlighting of buttons, labels, and more while manually allowing the highlighting of timestamps, file names, and other important information.
- Rename "Media Markup Tool" to "Audio Ninja" on splash screen
- Tweak spacing in markers list for small viewports