### PR TITLE
Implement pitch-preserving speed control

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -250,7 +250,6 @@ dependencies = [
  "csv",
  "parking_lot",
  "rtrb",
- "rubato",
  "serde",
  "serde_json",
  "symphonia",
@@ -2329,15 +2328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,15 +2342,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2983,15 +2964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,15 +3143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "realfft"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
-dependencies = [
- "rustfft",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,18 +3276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
-name = "rubato"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d18b486e7d29a408ef3f825bc1327d8f87af091c987ca2f5b734625940e234"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "realfft",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,20 +3288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustfft"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "primal-check",
- "strength_reduce",
- "transpose",
 ]
 
 [[package]]
@@ -3782,12 +3719,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -4756,16 +4687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ atomic_float      = "0.1"
 rtrb              = "0.3"
 cpal              = "0.15"
 symphonia         = { version = "0.5", features = ["all"] }
-rubato            = "0.15"
 csv               = "1"
 
 [dev-dependencies]

--- a/src-tauri/src/audio/decoder.rs
+++ b/src-tauri/src/audio/decoder.rs
@@ -278,7 +278,7 @@ fn decode_loop(
         let pts_ms = packet.ts() as f64 * 1000.0 / sample_rate as f64;
         state.set_position_ms(pts_ms);
 
-        // Optionally time-stretch via rubato.
+        // Optionally time-stretch to preserve pitch when speed != 1x.
         let samples_to_write: &[f32];
         let resampled: Vec<f32>;
         if let Some(r) = &mut resampler {

--- a/src-tauri/src/audio/resampler.rs
+++ b/src-tauri/src/audio/resampler.rs
@@ -1,105 +1,111 @@
-use rubato::{
-    Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType,
-    WindowFunction,
-};
-
-/// A thin wrapper around a rubato `SincFixedIn` resampler.
+/// Streaming tempo shifter using overlap-add (OLA).
 ///
-/// Used to apply pitch-preserving time-stretch when playback speed ≠ 1.0.
-/// At exactly 1.0x speed the wrapper is bypassed entirely in the decoder loop.
+/// This changes playback speed without explicit sample-rate conversion, which
+/// preserves perceived pitch substantially better than varispeed resampling.
 pub struct SpeedResampler {
-    inner: SincFixedIn<f32>,
-    /// Number of input frames consumed per process call.
-    chunk_size: usize,
     channels: usize,
-    /// Staging buffer for partial input (per channel).
+    speed: f64,
+    window_size: usize,
+    overlap: usize,
+    synthesis_hop: usize,
+    analysis_pos: f64,
     partial: Vec<Vec<f32>>,
+    prev_frame: Option<Vec<Vec<f32>>>,
 }
 
 impl SpeedResampler {
-    /// Create a resampler for `channels` channels at the given `speed`.
-    ///
-    /// `speed = 2.0` means the output is half the length (playing twice as fast).
-    /// The resampler ratio is therefore `1.0 / speed`.
     pub fn new(channels: usize, speed: f64) -> Self {
-        let ratio = 1.0 / speed;
-        // chunk_size is the number of input frames per process call.
-        // 1024 is a reasonable default that balances latency and quality.
-        let chunk_size = 1024usize;
-
-        let params = SincInterpolationParameters {
-            sinc_len: 256,
-            f_cutoff: 0.95,
-            interpolation: SincInterpolationType::Linear,
-            oversampling_factor: 128,
-            window: WindowFunction::BlackmanHarris2,
-        };
-
-        let inner = SincFixedIn::<f32>::new(
-            ratio,
-            2.0, // max_resample_ratio_relative
-            params,
-            chunk_size,
-            channels,
-        )
-        .expect("Failed to create resampler");
-
+        let speed = speed.clamp(0.1, 4.0);
+        let window_size = 1024usize;
+        let overlap = 256usize;
+        let synthesis_hop = window_size - overlap;
         Self {
-            inner,
-            chunk_size,
             channels,
+            speed,
+            window_size,
+            overlap,
+            synthesis_hop,
+            analysis_pos: 0.0,
             partial: vec![Vec::new(); channels],
+            prev_frame: None,
         }
     }
 
-    /// Feed interleaved `f32` samples and return resampled interleaved output.
-    ///
-    /// Internally buffers partial chunks until a full `chunk_size` worth of
-    /// frames has accumulated, then runs the resampler.
+    /// Feed interleaved samples and return time-stretched interleaved output.
     pub fn process_interleaved(&mut self, input: &[f32]) -> Vec<f32> {
-        // De-interleave into per-channel staging buffers.
+        if self.channels == 0 || input.is_empty() {
+            return Vec::new();
+        }
+
         for (i, &sample) in input.iter().enumerate() {
-            let ch = i % self.channels;
-            self.partial[ch].push(sample);
+            self.partial[i % self.channels].push(sample);
         }
 
-        let frames_available = self.partial[0].len();
-        if frames_available < self.chunk_size {
-            return Vec::new(); // not enough data yet
+        let analysis_hop = (self.synthesis_hop as f64 * self.speed).max(1.0);
+        let mut out_channels = vec![Vec::new(); self.channels];
+
+        loop {
+            let frame_start = self.analysis_pos.floor() as usize;
+            let available = self.partial[0].len();
+            if frame_start + self.window_size > available {
+                break;
+            }
+
+            let current_frame: Vec<Vec<f32>> = self
+                .partial
+                .iter()
+                .map(|ch_buf| ch_buf[frame_start..frame_start + self.window_size].to_vec())
+                .collect();
+
+            if let Some(prev) = &self.prev_frame {
+                for ch in 0..self.channels {
+                    for i in 0..self.overlap {
+                        let t = i as f32 / self.overlap as f32;
+                        let a = prev[ch][self.synthesis_hop + i];
+                        let b = current_frame[ch][i];
+                        out_channels[ch].push(a * (1.0 - t) + b * t);
+                    }
+                    for i in self.overlap..self.synthesis_hop {
+                        out_channels[ch].push(current_frame[ch][i]);
+                    }
+                }
+            } else {
+                for ch in 0..self.channels {
+                    out_channels[ch].extend_from_slice(&current_frame[ch][..self.synthesis_hop]);
+                }
+            }
+
+            self.prev_frame = Some(current_frame);
+            self.analysis_pos += analysis_hop;
         }
 
-        // Take exactly chunk_size frames from each channel.
-        let chunk: Vec<Vec<f32>> = self
-            .partial
-            .iter_mut()
-            .map(|ch_buf| {
-                let taken: Vec<f32> = ch_buf.drain(..self.chunk_size).collect();
-                taken
-            })
-            .collect();
-
-        match self.inner.process(&chunk, None) {
-            Ok(output_channels) => interleave(&output_channels),
-            Err(_) => Vec::new(),
+        // Keep enough lookback for the next frame start.
+        let drain_to = (self.analysis_pos.floor() as usize).saturating_sub(self.window_size);
+        if drain_to > 0 {
+            for ch in &mut self.partial {
+                ch.drain(..drain_to);
+            }
+            self.analysis_pos -= drain_to as f64;
         }
+
+        interleave(&out_channels)
     }
 
-    /// Discard any buffered partial input (call when seeking or changing speed).
     pub fn flush(&mut self) {
         for ch in &mut self.partial {
             ch.clear();
         }
+        self.prev_frame = None;
+        self.analysis_pos = 0.0;
     }
 }
 
-/// Interleave per-channel `Vec<f32>` into a single flat `Vec<f32>`.
 fn interleave(channels: &[Vec<f32>]) -> Vec<f32> {
     if channels.is_empty() {
         return Vec::new();
     }
     let frames = channels[0].len();
-    let ch_count = channels.len();
-    let mut out = Vec::with_capacity(frames * ch_count);
+    let mut out = Vec::with_capacity(frames * channels.len());
     for f in 0..frames {
         for ch in channels {
             if f < ch.len() {
@@ -116,12 +122,10 @@ mod tests {
 
     #[test]
     fn double_speed_output_is_approximately_half_input_length() {
-        // 2.0x speed → ratio 0.5 → output ≈ half the frames
+        // 2.0x speed should emit fewer output samples than input.
         let mut r = SpeedResampler::new(1, 2.0);
-        // Feed enough frames to trigger at least one process call.
-        let input: Vec<f32> = (0..2048).map(|i| (i as f32).sin()).collect();
+        let input: Vec<f32> = (0..8192).map(|i| (i as f32).sin()).collect();
         let output = r.process_interleaved(&input);
-        // Expect output roughly half the input (within a generous tolerance).
         assert!(!output.is_empty(), "Expected non-empty output");
         assert!(
             output.len() < input.len(),
@@ -134,16 +138,13 @@ mod tests {
     #[test]
     fn half_speed_produces_more_output_than_input_after_warmup() {
         let mut r = SpeedResampler::new(1, 0.5);
-        // The sinc resampler has startup latency; feed many chunks so the filter
-        // warms up and the cumulative output/input ratio approaches 2.0.
-        let chunk = vec![0.0f32; 1024];
+        let chunk = vec![0.0f32; 2048];
         let mut total_output = 0usize;
-        let iterations = 20;
+        let iterations = 10;
         for _ in 0..iterations {
             total_output += r.process_interleaved(&chunk).len();
         }
-        let total_input = 1024 * iterations;
-        // After warmup, total output should exceed total input for 0.5× speed.
+        let total_input = chunk.len() * iterations;
         assert!(
             total_output > total_input,
             "After warmup, output ({total_output}) should exceed input ({total_input}) at 0.5x speed"
@@ -157,8 +158,11 @@ mod tests {
         let partial_input: Vec<f32> = vec![0.0f32; 100];
         r.process_interleaved(&partial_input);
         assert_eq!(r.partial[0].len(), 100);
+        assert!(r.prev_frame.is_none());
         r.flush();
         assert_eq!(r.partial[0].len(), 0);
+        assert!(r.prev_frame.is_none());
+        assert_eq!(r.analysis_pos, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
Implemented pitch-preserving speed control in the Tauri audio engine so changing playback rate no longer shifts voice/instrument pitch. The backend now uses a lightweight overlap-add time-stretch path instead of varispeed resampling, while keeping existing play/pause/seek/speed controls intact.