### PR TITLE
Error Improvements and Drag and Drop Files to Open

### DIFF
--- a/docs/developer-documentation/index.md
+++ b/docs/developer-documentation/index.md
@@ -188,7 +188,8 @@ Maintenance note: the main export UI calls `export_audio_segments`, which can ex
 - Change marker or segment data shape: update `src-tauri/src/markers/model.rs`, `src/lib/types.ts`, CSV import/export code, and tests.
 - Change keyboard shortcuts: edit `src/lib/shortcuts.ts` and `src/components/ShortcutsPanel.svelte`.
 - Change where shortcuts are persisted: edit `read_shortcuts_config` and `write_shortcuts_config` in `src-tauri/src/commands.rs`.
-- Change supported input file types: update the dialog filter in `open_file_dialog` in `src-tauri/src/commands.rs`, confirm Symphonia supports the format, and update user-facing docs.
+- Change supported input file types: update the dialog filter in `open_file_dialog` in `src-tauri/src/commands.rs`, the matching `SUPPORTED_MEDIA_EXTENSIONS` constant in `src/lib/actions.ts`, confirm Symphonia supports the format, and update user-facing docs.
+- Change drag-and-drop behavior: edit the `onDragDropEvent` handler in `src/routes/+page.svelte` and `openFileFromPath` in `src/lib/actions.ts`.
 - Change audio decoding/playback behavior: start in `src-tauri/src/audio/engine.rs`, then inspect `decoder.rs`, `output.rs`, `control.rs`, and `resampler.rs`.
 - Change export filenames or FFmpeg arguments: edit `src-tauri/src/export/segments.rs`.
 - Change CSV format: edit `src-tauri/src/export/csv.rs`, update import/export tests, and update user documentation if the file format changes.
@@ -201,7 +202,7 @@ Maintenance note: the main export UI calls `export_audio_segments`, which can ex
 
 ### Opening a File
 
-`WelcomeScreen.svelte` or `Header.svelte` calls `openFile()` in `src/lib/actions.ts`. That invokes `open_file_dialog` in `src-tauri/src/commands.rs`. The backend opens a native dialog, constructs an `AudioEngine`, stores it in `AppState`, clears old markers, and returns file metadata to the frontend.
+`WelcomeScreen.svelte` or `Header.svelte` calls `openFile()` in `src/lib/actions.ts`. That invokes `open_file_dialog` in `src-tauri/src/commands.rs`. The backend opens a native dialog, constructs an `AudioEngine`, stores it in `AppState`, clears old markers, and returns file metadata to the frontend. Files dropped on the app window are handled by `src/routes/+page.svelte`, which listens for Tauri's `onDragDropEvent` and calls `openFileFromPath()` in `src/lib/actions.ts`; that path skips the dialog and invokes `open_file` directly with the dropped path.
 
 ### Playback and Seeking
 

--- a/docs/user-documentation/index.md
+++ b/docs/user-documentation/index.md
@@ -9,7 +9,7 @@
 
 ## Functionality 
 
-When the app is first opened the user is presented with a dialog that allows them to select an audio file. The supported audio file formats can be found [here](#supported-audio-file-formats). After the user has selected an audio file, they are presented with the application's main user interface. This interface has four main components:
+When the app is first opened the user is presented with a dialog that allows them to select an audio file, either by clicking the Choose File button or by dragging and dropping a file onto the app window. The supported audio file formats can be found [here](#supported-audio-file-formats). After the user has selected an audio file, they are presented with the application's main user interface. This interface has four main components:
 
 - [Waveform Diagram](#waveform-diagram)
 - [Marker List](#marker-list)
@@ -54,4 +54,4 @@ In addition to the base functionality listed above there are a few other feature
 
 The first feature we would like to highlight is that when users have finished placing their markers and are ready to export they can choose to either export the audio segments, the CSV with all of segments, or both. If the user chooses to export the CSV with all of their markers they will be able to pick up progress in another session by clicking the import CSV button in the top right and selecting the CSV file. 
 
-Users can also select the Open File button to import a new audio file and reset the applications state. Be weary that if a new audio file is opened without first exporting the current progress then that progress will not be saved. 
+Users can also select the Open File button, or drag and drop a new file onto the window, to import a new audio file and reset the applications state. Be weary that if a new audio file is opened without first exporting the current progress then that progress will not be saved. 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,23 +40,28 @@ pub async fn open_file(
 }
 
 /// Show the native file-open dialog, then open the chosen file.
+///
+/// Returns `Ok(None)` when the user closes the dialog without picking a file —
+/// cancellation is an expected outcome rather than an error condition.
 #[tauri::command]
 pub async fn open_file_dialog(
     app: AppHandle,
     state: State<'_, AppState>,
-) -> Result<FileMetadata> {
+) -> Result<Option<FileMetadata>> {
     use tauri_plugin_dialog::DialogExt;
 
-    let path = app
+    let Some(path) = app
         .dialog()
         .file()
         .add_filter("Audio / Video", &["mp3", "mp4", "wav", "flac", "ogg", "aac", "m4a"])
         .blocking_pick_file()
-        .ok_or(AppError::DialogCancelled)?;
+    else {
+        return Ok(None);
+    };
 
     let path_str = path.to_string();
 
-    open_file(path_str, state).await
+    open_file(path_str, state).await.map(Some)
 }
 
 // ---------------------------------------------------------------------------
@@ -203,19 +208,23 @@ pub async fn validate_markers(state: State<'_, AppState>) -> Result<Vec<Segment>
 
 /// Open a CSV file dialog, parse the selected file, replace all current markers
 /// with the imported segments, and return the new marker list.
+///
+/// Returns `Ok(None)` when the user closes the dialog without picking a file.
 #[tauri::command]
 pub async fn import_csv(
     app: AppHandle,
     state: State<'_, AppState>,
-) -> Result<Vec<Marker>> {
+) -> Result<Option<Vec<Marker>>> {
     use tauri_plugin_dialog::DialogExt;
 
-    let path = app
+    let Some(path) = app
         .dialog()
         .file()
         .add_filter("CSV", &["csv"])
         .blocking_pick_file()
-        .ok_or(AppError::DialogCancelled)?;
+    else {
+        return Ok(None);
+    };
 
     let file = std::fs::File::open(path.to_string())?;
     let segments = import_markers_from_reader(file)?;
@@ -263,7 +272,7 @@ pub async fn import_csv(
         }
     }
 
-    Ok(store.list().to_vec())
+    Ok(Some(store.list().to_vec()))
 }
 
 // ---------------------------------------------------------------------------
@@ -272,14 +281,15 @@ pub async fn import_csv(
 
 /// Validate the current markers into segments, open a folder-picker dialog, then
 /// extract each segment from the loaded audio file using the bundled ffmpeg sidecar.
-/// Returns the number of segment files written.
+/// Returns the number of segment files written, or `Ok(None)` if the user
+/// cancelled the folder picker.
 #[tauri::command]
 pub async fn export_audio_segments(
     app: AppHandle,
     state: State<'_, AppState>,
     export_csv: bool, 
     export_audio: bool, 
-) -> Result<u32> {
+) -> Result<Option<u32>> {
     use tauri_plugin_dialog::DialogExt;
 
     let segments = state.markers.lock().to_segments()?;
@@ -292,17 +302,17 @@ pub async fn export_audio_segments(
         engine.as_ref().ok_or(AppError::NoFileLoaded)?.metadata.file_path.clone()
     };
 
-    let output_dir = app
-        .dialog()
-        .file()
-        .blocking_pick_folder()
-        .ok_or(AppError::DialogCancelled)?;
+    let Some(output_dir) = app.dialog().file().blocking_pick_folder() else {
+        return Ok(None);
+    };
 
     let output_path = output_dir
         .as_path()
         .ok_or_else(|| AppError::ValidationError("Invalid output directory path".into()))?;
 
-    export_segments(&app, &source_path, &segments, output_path, export_csv, export_audio).await
+    export_segments(&app, &source_path, &segments, output_path, export_csv, export_audio)
+        .await
+        .map(Some)
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -18,8 +18,6 @@ pub enum AppError {
     AudioOutput(String),
     #[error("CSV error: {0}")]
     Csv(#[from] csv::Error),
-    #[error("Dialog cancelled")]
-    DialogCancelled,
     #[error("ffmpeg sidecar not available: {0}")]
     FfmpegNotFound(String),
     #[error("ffmpeg failed on segment '{0}': {1}")]
@@ -57,7 +55,6 @@ mod tests {
             AppError::Decode("corrupt".into()),
             AppError::AudioOutput("no device".into()),
             AppError::Csv(csv_err),
-            AppError::DialogCancelled,
             AppError::FfmpegNotFound("/usr/bin/ffmpeg".into()),
             AppError::FfmpegFailed("seg1".into(), "exit code 1".into()),
         ];

--- a/src/components/ErrorAlert.svelte
+++ b/src/components/ErrorAlert.svelte
@@ -19,7 +19,7 @@
     </div>
     <div class="alert-body">
       <p id="alert-title" class="alert-title">Error</p>
-      <p class="alert-message">{appState.error}</p>
+      <p class="alert-message copyable-text">{appState.error}</p>
     </div>
     <button class="btn-dismiss" onclick={dismiss}>OK</button>
   </div>

--- a/src/components/SegmentPanel.svelte
+++ b/src/components/SegmentPanel.svelte
@@ -17,7 +17,7 @@
   </div>
 
   {#if appState.validationError}
-    <p class="validation-error">{appState.validationError}</p>
+    <p class="validation-error copyable-text">{appState.validationError}</p>
   {/if}
 
   {#if displaySegments.length === 0}

--- a/src/components/WelcomeScreen.svelte
+++ b/src/components/WelcomeScreen.svelte
@@ -20,7 +20,7 @@
     <h2>Open a media file to begin</h2>
     <p class="upload-formats">Supported formats: MP4, MP3, WAV, FLAC, OGG, AAC</p>
     {#if appState.error}
-      <p class="error-text">{appState.error}</p>
+      <p class="error-text copyable-text">{appState.error}</p>
     {/if}
     <button class="btn-primary" onclick={onOpenFile}>Choose File</button>
   </div>

--- a/src/components/WelcomeScreen.svelte
+++ b/src/components/WelcomeScreen.svelte
@@ -18,7 +18,8 @@
       </svg>
     </div>
     <h2>Open a media file to begin</h2>
-    <p class="upload-formats">Supported formats: MP4, MP3, WAV, FLAC, OGG, AAC</p>
+    <p class="upload-formats">Supported formats: MP4, MP3, WAV, FLAC, OGG, AAC, M4A</p>
+    <p class="upload-hint">Drag &amp; drop a file anywhere, or</p>
     {#if appState.error}
       <p class="error-text copyable-text">{appState.error}</p>
     {/if}
@@ -90,6 +91,12 @@
   .upload-formats {
     font-size: 12px;
     color: #8b949e;
+  }
+
+  .upload-hint {
+    font-size: 11px;
+    color: #6b7280;
+    margin-top: 2px;
   }
 
   .error-text {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -217,6 +217,35 @@ export async function stepFwd() {
 
 // ── IPC handlers ──────────────────────────────────────────────────────────
 
+// Media extensions the backend's `open_file` command knows how to decode.
+// Keep in sync with the file-picker filter in `commands.rs::open_file_dialog`.
+export const SUPPORTED_MEDIA_EXTENSIONS = [
+  'mp3', 'mp4', 'wav', 'flac', 'ogg', 'aac', 'm4a',
+] as const;
+
+export function isSupportedMediaPath(path: string): boolean {
+  const dot = path.lastIndexOf('.');
+  if (dot < 0) return false;
+  const ext = path.slice(dot + 1).toLowerCase();
+  return (SUPPORTED_MEDIA_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+// Apply the post-open state reset shared by every code path that loads a
+// fresh media file (file dialog, drag-and-drop, etc.).
+function applyLoadedMetadata(meta: FileMetadata) {
+  appState.metadata        = meta;
+  appState.durationMs      = meta.durationMs;
+  appState.positionMs      = 0;
+  appState.markers          = [];
+  appState.segments         = null;
+  appState.renameInputs     = {};
+  appState.selectedMarkerId = null;
+  appState.editingMarkerId  = null;
+  appState.editingPositionMs = 0;
+  startPolling();
+  startRaf();
+}
+
 export async function openFile() {
   try {
     appState.error = null;
@@ -225,17 +254,27 @@ export async function openFile() {
     // The backend returns `null` (Rust `Ok(None)`) when the user dismisses the
     // native file picker — treat that as a no-op rather than an error.
     if (meta == null) return;
-    appState.metadata        = meta;
-    appState.durationMs      = meta.durationMs;
-    appState.positionMs      = 0;
-    appState.markers          = [];
-    appState.segments         = null;
-    appState.renameInputs     = {};
-    appState.selectedMarkerId = null;
-    appState.editingMarkerId  = null;
-    appState.editingPositionMs = 0;
-    startPolling();
-    startRaf();
+    applyLoadedMetadata(meta);
+  } catch (e) {
+    appState.error = String(e);
+  }
+}
+
+/**
+ * Open a media file at the given absolute path (e.g. from a drag-and-drop).
+ * Silently ignores paths whose extension isn't in {@link SUPPORTED_MEDIA_EXTENSIONS}
+ * so that unrelated files dropped on the window don't trigger a backend error.
+ */
+export async function openFileFromPath(path: string) {
+  if (!isSupportedMediaPath(path)) {
+    appState.error = `Unsupported file type: ${path}`;
+    return;
+  }
+  try {
+    appState.error = null;
+    appState.successMessage = null;
+    const meta = await invoke<FileMetadata>('open_file', { path });
+    applyLoadedMetadata(meta);
   } catch (e) {
     appState.error = String(e);
   }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -221,7 +221,10 @@ export async function openFile() {
   try {
     appState.error = null;
     appState.successMessage = null;
-    const meta = await invoke<FileMetadata>('open_file_dialog');
+    const meta = await invoke<FileMetadata | null>('open_file_dialog');
+    // The backend returns `null` (Rust `Ok(None)`) when the user dismisses the
+    // native file picker — treat that as a no-op rather than an error.
+    if (meta == null) return;
     appState.metadata        = meta;
     appState.durationMs      = meta.durationMs;
     appState.positionMs      = 0;
@@ -499,7 +502,8 @@ export async function exportAudioSegments(exportCsv: boolean, exportAudio: boole
   try {
     appState.error = null;
     appState.successMessage = null;
-    await invoke('export_audio_segments', {exportCsv, exportAudio});
+    const count = await invoke<number | null>('export_audio_segments', {exportCsv, exportAudio});
+    if (count === null) return; // user cancelled the folder picker
     if (exportCsv && exportAudio) appState.successMessage = 'CSV and audio segments exported successfully.';
     else if (exportCsv) appState.successMessage = 'CSV exported successfully.';
     else if (exportAudio) appState.successMessage = 'Audio segments exported successfully.';
@@ -512,7 +516,8 @@ export async function importCsv() {
   try {
     appState.error = null;
     appState.successMessage = null;
-    const markers = await invoke<Marker[]>('import_csv');
+    const markers = await invoke<Marker[] | null>('import_csv');
+    if (!markers) return; // user cancelled the file picker
     appState.markers = markers.sort((a, b) => a.position - b.position);
     appState.renameInputs = Object.fromEntries(
       markers.filter(m => m.kind !== 'end').map(m => [m.id, ''])
@@ -523,8 +528,6 @@ export async function importCsv() {
     appState.unkindedMarkers = new Set();
     await revalidate();
   } catch (e) {
-    if (String(e) !== 'Dialog cancelled') {
-      appState.error = String(e);
-    }
+    appState.error = String(e);
   }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { getCurrentWebview } from '@tauri-apps/api/webview';
   import { appState } from '$lib/state.svelte';
   import {
     stopPolling, stopRaf, handleKeydown, loadShortcuts,
-    openFile, importCsv, togglePlay, setSpeed, handleLoop,
+    openFile, openFileFromPath, isSupportedMediaPath,
+    importCsv, togglePlay, setSpeed, handleLoop,
     addMarkerNoKind, addMarkerAt, deleteMarker, splitStartEndMarker,
     renameSegment, exportAudioSegments,
     stepBack, stepFwd, handleFollowPlayhead
@@ -20,6 +22,10 @@
   import SuccessToast from '../components/SuccessToast.svelte';
 
   let shortcutsCollapsed = $state(false);
+  // Drag-and-drop hover state — we listen to the OS-level event from the
+  // Tauri webview (not HTML5 dragover/drop, which don't deliver real paths).
+  let dragHover     = $state(false);
+  let dragSupported = $state(true);
 
   onMount(() => {
     loadShortcuts();
@@ -31,9 +37,33 @@
     syncShortcutsLayout();
     media.addEventListener('change', syncShortcutsLayout);
 
+    // Tauri's webview emits OS-level drag-drop events with absolute paths.
+    // Only the first dropped file is opened; extras are ignored.
+    let unlistenDragDrop: (() => void) | null = null;
+    getCurrentWebview()
+      .onDragDropEvent((event) => {
+        const p = event.payload;
+        if (p.type === 'enter') {
+          dragSupported = p.paths.some(isSupportedMediaPath);
+          dragHover = true;
+        } else if (p.type === 'leave') {
+          dragHover = false;
+        } else if (p.type === 'drop') {
+          dragHover = false;
+          const target = p.paths.find(isSupportedMediaPath) ?? p.paths[0];
+          if (target) openFileFromPath(target);
+        }
+      })
+      .then((unlisten) => { unlistenDragDrop = unlisten; })
+      .catch(() => {
+        // Listener unavailable (e.g. running outside Tauri in unit tests) —
+        // drag-and-drop simply won't be wired up.
+      });
+
     return () => {
       document.removeEventListener('keydown', handleKeydown);
       media.removeEventListener('change', syncShortcutsLayout);
+      if (unlistenDragDrop) unlistenDragDrop();
     };
   });
 
@@ -46,6 +76,20 @@
 
 <ErrorAlert />
 <SuccessToast />
+
+{#if dragHover}
+  <div class="drop-overlay" class:drop-overlay-invalid={!dragSupported}>
+    <div class="drop-overlay-card">
+      {#if dragSupported}
+        <p class="drop-overlay-title">Drop to open</p>
+        <p class="drop-overlay-sub">{appState.metadata ? 'Replaces the currently loaded file' : 'MP4, MP3, WAV, FLAC, OGG, AAC, M4A'}</p>
+      {:else}
+        <p class="drop-overlay-title">Unsupported file type</p>
+        <p class="drop-overlay-sub">Supported: MP4, MP3, WAV, FLAC, OGG, AAC, M4A</p>
+      {/if}
+    </div>
+  </div>
+{/if}
 
 {#if !appState.metadata}
   <WelcomeScreen onOpenFile={openFile} />
@@ -139,6 +183,48 @@
 	      grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr) 58px;
 	    }
 	  }
+
+  .drop-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    background: rgba(13, 17, 23, 0.78);
+    border: 3px dashed #3b82f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    backdrop-filter: blur(2px);
+  }
+
+  .drop-overlay-invalid {
+    border-color: #f87171;
+    background: rgba(40, 13, 13, 0.78);
+  }
+
+  .drop-overlay-card {
+    text-align: center;
+    color: #e2e8f0;
+    padding: 24px 40px;
+    border-radius: 12px;
+    background: rgba(22, 27, 34, 0.9);
+    border: 1px solid #30363d;
+  }
+
+  .drop-overlay-title {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+
+  .drop-overlay-invalid .drop-overlay-title {
+    color: #f87171;
+  }
+
+  .drop-overlay-sub {
+    font-size: 12px;
+    color: #8b949e;
+  }
 
   :global(::-webkit-scrollbar) { width: 6px; }
   :global(::-webkit-scrollbar-track) { background: transparent; }

--- a/src/tests/unit/actions.import.test.ts
+++ b/src/tests/unit/actions.import.test.ts
@@ -115,9 +115,24 @@ describe('importCsv', () => {
   });
 
   it('does not set appState.error when dialog is cancelled', async () => {
-    mockIPC(() => { throw 'Dialog cancelled'; });
+    // Backend signals cancellation by resolving with `null` rather than rejecting.
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return null;
+      return undefined;
+    });
     await importCsv();
     expect(appState.error).toBeNull();
+  });
+
+  it('leaves existing markers untouched when dialog is cancelled', async () => {
+    appState.markers = [marker('keep', 500, 'start')];
+    mockIPC((cmd: string) => {
+      if (cmd === 'import_csv') return null;
+      return undefined;
+    });
+    await importCsv();
+    expect(appState.markers).toHaveLength(1);
+    expect(appState.markers[0].id).toBe('keep');
   });
 
   it('sets appState.error on other failures', async () => {

--- a/src/tests/unit/actions.playback.test.ts
+++ b/src/tests/unit/actions.playback.test.ts
@@ -138,9 +138,18 @@ describe('openFile', () => {
   });
 
   it('sets appState.error when the dialog throws', async () => {
-    mockIPC(() => { throw new Error('cancelled'); });
+    mockIPC(() => { throw new Error('boom'); });
     await openFile();
-    expect(appState.error).toMatch('cancelled');
+    expect(appState.error).toMatch('boom');
+  });
+
+  it('does nothing when the dialog is cancelled (returns null)', async () => {
+    appState.metadata = null;
+    appState.error = null;
+    mockIPC(() => null);
+    await openFile();
+    expect(appState.metadata).toBeNull();
+    expect(appState.error).toBeNull();
   });
 });
 


### PR DESCRIPTION
- Allow copying of error text
- Prevent exiting the file dialog on the welcome screen from showing an error. Instead, the app just returns to the welcome screen. This is in line with the other open file button in the main view of the app
- Allow users to drag-and-drop files directly into the app. An error is displayed when the file is of an unsupported extension