### PR TITLE
Fix: waveform resizing issue + seek to end command

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -92,11 +92,8 @@ pub async fn pause(state: State<'_, AppState>) -> Result<()> {
 pub async fn seek(state: State<'_, AppState>, position_ms: u64) -> Result<()> {
     let engine = state.engine.lock();
     let engine = engine.as_ref().ok_or(AppError::NoFileLoaded)?;
-    let duration = engine.state.get_duration_ms() as u64;
-    if position_ms > duration {
-        return Err(AppError::SeekOutOfRange(position_ms));
-    }
-    engine.seek(position_ms)
+    let target = clamp_seek_to_duration(position_ms, engine.state.get_duration_ms());
+    engine.seek(target)
 }
 
 #[tauri::command]
@@ -352,4 +349,31 @@ fn parse_uuid(s: &str) -> Result<Uuid> {
     Uuid::parse_str(s).map_err(|_| {
         AppError::ValidationError(format!("Invalid UUID: {s}"))
     })
+}
+
+fn clamp_seek_to_duration(position_ms: u64, duration_ms: f64) -> u64 {
+    if duration_ms <= 0.0 {
+        return position_ms;
+    }
+    position_ms.min(duration_ms.floor() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_seek_to_duration;
+
+    #[test]
+    fn clamp_seek_allows_positions_with_unknown_duration() {
+        assert_eq!(clamp_seek_to_duration(5000, 0.0), 5000);
+    }
+
+    #[test]
+    fn clamp_seek_floors_fractional_duration_boundary() {
+        assert_eq!(clamp_seek_to_duration(5_039_334, 5_039_333.7), 5_039_333);
+    }
+
+    #[test]
+    fn clamp_seek_keeps_in_range_position() {
+        assert_eq!(clamp_seek_to_duration(1200, 5000.0), 1200);
+    }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -4,8 +4,6 @@ use uuid::Uuid;
 pub enum AppError {
     #[error("No file loaded")]
     NoFileLoaded,
-    #[error("Seek out of range: {0} ms")]
-    SeekOutOfRange(u64),
     #[error("Marker not found: {0}")]
     MarkerNotFound(Uuid),
     #[error("Validation failed: {0}")]
@@ -48,7 +46,6 @@ mod tests {
 
         let cases: Vec<AppError> = vec![
             AppError::NoFileLoaded,
-            AppError::SeekOutOfRange(500),
             AppError::MarkerNotFound(uuid),
             AppError::ValidationError("bad input".into()),
             AppError::Io(io_err),

--- a/src/components/WaveformDisplay.svelte
+++ b/src/components/WaveformDisplay.svelte
@@ -20,6 +20,7 @@
   let waveformWrapEl = $state<HTMLDivElement | null>(null);
   let waveformResizeQueued = false;
   let lastWaveformWidth = 0;
+  let lastWaveformHeight = 0;
   // The zoom level that WaveSurfer's canvas was last rendered at. While the
   // user is mid-gesture (wheel/pinch zoom), we defer the (expensive) WaveSurfer
   // re-render and instead CSS-scale the rendered canvas to match the current
@@ -99,9 +100,18 @@
       // the visual update. We'll re-render once the gesture settles.
       if (zoomRenderDeferred) return;
       const width = Math.round(waveformEl.clientWidth);
+      const height = Math.round((waveformWrapEl?.clientHeight || 0) - TIMELINE_HEIGHT);
+      const options: { width?: number; height?: number } = {};
       if (width > 0 && width !== lastWaveformWidth) {
         lastWaveformWidth = width;
-        appState.wavesurfer.setOptions({ width });
+        options.width = width;
+      }
+      if (height > 0 && height !== lastWaveformHeight) {
+        lastWaveformHeight = height;
+        options.height = height;
+      }
+      if (options.width || options.height) {
+        appState.wavesurfer.setOptions(options);
         lastRenderedZoom = appState.zoomLevel;
       }
     });
@@ -117,9 +127,18 @@
     zoomRenderDeferred = false;
     if (!appState.wavesurfer || !waveformEl || !appState.metadata) return;
     const width = Math.round(waveformEl.clientWidth);
+    const height = Math.round((waveformWrapEl?.clientHeight || 0) - TIMELINE_HEIGHT);
+    const options: { width?: number; height?: number } = {};
     if (width > 0 && width !== lastWaveformWidth) {
       lastWaveformWidth = width;
-      appState.wavesurfer.setOptions({ width });
+      options.width = width;
+    }
+    if (height > 0 && height !== lastWaveformHeight) {
+      lastWaveformHeight = height;
+      options.height = height;
+    }
+    if (options.width || options.height) {
+      appState.wavesurfer.setOptions(options);
     }
     lastRenderedZoom = appState.zoomLevel;
   }
@@ -192,6 +211,7 @@
     ws.load(convertFileSrc(filePath));
     appState.wavesurfer = ws;
     lastWaveformWidth = 0;
+    lastWaveformHeight = 0;
     // Read zoom via untrack so this $effect doesn't depend on zoomLevel —
     // otherwise every zoom change would tear down and recreate WaveSurfer
     // and reset the zoom back to default.
@@ -203,9 +223,8 @@
     }
     queueWaveformResize();
 
-    const resizeObserver = new ResizeObserver(([entry]) => {
-      const height = Math.round(entry.contentRect.height) - TIMELINE_HEIGHT;
-      if (height > 0) ws.setOptions({ height });
+    const resizeObserver = new ResizeObserver(() => {
+      queueWaveformResize();
     });
     if (waveformWrapEl) resizeObserver.observe(waveformWrapEl);
 
@@ -428,7 +447,7 @@
         {/each}
         {#each ticks.major as tick (tick.pct)}
           <div class="tick-major" style="left: {tick.pct}%">
-            <span class="tick-label">{tick.label}</span>
+            <span class="tick-label" class:tick-label-right={tick.pct > 92}>{tick.label}</span>
           </div>
         {/each}
       </div>
@@ -560,6 +579,11 @@
     user-select: none;
     font-variant-numeric: tabular-nums;
     line-height: 1;
+  }
+
+  .tick-label-right {
+    left: auto;
+    right: 3px;
   }
 
   .tick-minor {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -193,16 +193,20 @@ export function centerWaveformAt(ms: number) {
 }
 
 export async function seekTo(ms: number, options: { centerWaveform?: boolean } = {}) {
+  const clampedMs = appState.durationMs > 0
+    ? Math.min(Math.max(ms, 0), appState.durationMs)
+    : Math.max(ms, 0);
+  const positionMs = Math.floor(clampedMs);
   try {
-    await invoke('seek', { positionMs: Math.round(ms) });
-    appState.positionMs     = ms;
-    appState.syncPositionMs = ms;
+    await invoke('seek', { positionMs });
+    appState.positionMs     = clampedMs;
+    appState.syncPositionMs = clampedMs;
     appState.syncWallTime   = performance.now();
     if (appState.wavesurfer && appState.durationMs > 0) {
-      appState.wavesurfer.setTime(ms / 1000);
+      appState.wavesurfer.setTime(clampedMs / 1000);
     }
     if (options.centerWaveform || appState.followPlayhead) {
-      centerWaveformAt(ms);
+      centerWaveformAt(clampedMs);
     }
   } catch (e) {
     appState.error = String(e);

--- a/src/tests/unit/actions.seeking.test.ts
+++ b/src/tests/unit/actions.seeking.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockIPC } from '@tauri-apps/api/mocks';
 import { appState } from '$lib/state.svelte';
-import { seekTo, selectMarker, seekToPrevMarker, seekToNextMarker, stepBack, stepFwd, handleFollowPlayhead } from '$lib/actions';
+import { seekTo, seekToEnd, selectMarker, seekToPrevMarker, seekToNextMarker, stepBack, stepFwd, handleFollowPlayhead } from '$lib/actions';
 import { resetAppState } from '../helpers/reset-state';
 import type { Marker } from '$lib/types';
 
@@ -21,11 +21,11 @@ describe('seekTo', () => {
     expect(appState.syncPositionMs).toBe(2500);
   });
 
-  it('sends the rounded position to invoke', async () => {
+  it('sends the floored position to invoke', async () => {
     const handler = vi.fn(() => undefined);
     mockIPC(handler);
     await seekTo(2500.7);
-    expect(handler).toHaveBeenCalledWith('seek', { positionMs: 2501 });
+    expect(handler).toHaveBeenCalledWith('seek', { positionMs: 2500 });
   });
 
   it('stores the unrounded value in state', async () => {
@@ -45,6 +45,15 @@ describe('seekTo', () => {
     mockIPC(() => { throw new Error('oops'); });
     await seekTo(5000);
     expect(appState.positionMs).toBe(1000);
+  });
+
+  it('does not round fractional durations past the end when seeking to end', async () => {
+    const handler = vi.fn(() => undefined);
+    mockIPC(handler);
+    appState.durationMs = 5_039_333.7;
+    await seekToEnd();
+    expect(handler).toHaveBeenCalledWith('seek', { positionMs: 5_039_333 });
+    expect(appState.positionMs).toBe(5_039_333.7);
   });
 });
 


### PR DESCRIPTION
This PR addresses issues with the waveform rendering as the window is resized, and the seek to end command not working as expected.

When the waveform is first rendered after a file is chosen, it is fit to the size of the current window. However, when the window size is changed, the width of the waveform is adapted and either leaves unfilled space to the right or overflows. This includes the tick mark bar below the waveform. The code has been updated to call `queueWaveformResize()` in WaveformDisplay.svelte on changes to the windows width as well as height. 

Additionally, for larger audio files (> 80 minutes in my testing), the seek to end command via default keyboard shortcut 'W' caused the error below to be thrown due to a rounding mismatch between the audio file duration communicated between the backend and frontend. 

<img width="942" height="508" alt="image" src="https://github.com/user-attachments/assets/8c561d11-c80e-47bb-a29b-e65abcb5123a" />

The code has been updated to clamp a seek command the total duration of a file rather than throwing 'out of bounds' errors.  The frontend now floors values before sending them to the backend so out of bounds scenarios are not encountered for fractional playback position values. 